### PR TITLE
Add Bellway and Ventrica warp items

### DIFF
--- a/ItemChanger.Silksong/RawData/BaseItemList.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList.cs
@@ -1,4 +1,4 @@
-﻿using ItemChanger.Items;
+using ItemChanger.Items;
 using ItemChanger.Serialization;
 using ItemChanger.Silksong.Items;
 using ItemChanger.Silksong.Serialization;
@@ -21,23 +21,23 @@ internal static partial class BaseItemList
         },
     };
 
-    public static Item Bellway__Deep_Docks => new PDBoolItem { Name = ItemNames.Bellway__Deep_Docks, BoolName = "UnlockedDocksStation" };
-    public static Item Bellway__Far_Fields => new PDBoolItem { Name = ItemNames.Bellway__Far_Fields, BoolName = "UnlockedBoneforestEastStation" };
-    public static Item Bellway__Greymoor => new PDBoolItem { Name = ItemNames.Bellway__Greymoor, BoolName = "UnlockedGreymoorStation" };
-    public static Item Bellway__Bellhart => new PDBoolItem { Name = ItemNames.Bellway__Bellhart, BoolName = "UnlockedBelltownStation" };
-    public static Item Bellway__Blasted_Steps => new PDBoolItem { Name = ItemNames.Bellway__Blasted_Steps, BoolName = "UnlockedCoralTowerStation" };
-    public static Item Bellway__Grand_Bellway => new PDBoolItem { Name = ItemNames.Bellway__Grand_Bellway, BoolName = "UnlockedCityStation" };
-    public static Item Bellway__The_Slab => new PDBoolItem { Name = ItemNames.Bellway__The_Slab, BoolName = "UnlockedPeakStation" };
-    public static Item Bellway__Shellwood => new PDBoolItem { Name = ItemNames.Bellway__Shellwood, BoolName = "UnlockedShellwoodStation" };
-    public static Item Bellway__Bilewater => new PDBoolItem { Name = ItemNames.Bellway__Bilewater, BoolName = "UnlockedShadowStation" };
-    public static Item Bellway__Putrified_Ducts => new PDBoolItem { Name = ItemNames.Bellway__Putrified_Ducts, BoolName = "UnlockedAqueductStation" };
+    public static Item Bellway__Deep_Docks => new PDBoolItem { Name = ItemNames.Bellway__Deep_Docks, BoolName = nameof(PlayerData.UnlockedDocksStation) };
+    public static Item Bellway__Far_Fields => new PDBoolItem { Name = ItemNames.Bellway__Far_Fields, BoolName = nameof(PlayerData.UnlockedBoneforestEastStation) };
+    public static Item Bellway__Greymoor => new PDBoolItem { Name = ItemNames.Bellway__Greymoor, BoolName = nameof(PlayerData.UnlockedGreymoorStation) };
+    public static Item Bellway__Bellhart => new PDBoolItem { Name = ItemNames.Bellway__Bellhart, BoolName = nameof(PlayerData.UnlockedBelltownStation) };
+    public static Item Bellway__Blasted_Steps => new PDBoolItem { Name = ItemNames.Bellway__Blasted_Steps, BoolName = nameof(PlayerData.UnlockedCoralTowerStation) };
+    public static Item Bellway__Grand_Bellway => new PDBoolItem { Name = ItemNames.Bellway__Grand_Bellway, BoolName = nameof(PlayerData.UnlockedCityStation) };
+    public static Item Bellway__The_Slab => new PDBoolItem { Name = ItemNames.Bellway__The_Slab, BoolName = nameof(PlayerData.UnlockedPeakStation) };
+    public static Item Bellway__Shellwood => new PDBoolItem { Name = ItemNames.Bellway__Shellwood, BoolName = nameof(PlayerData.UnlockedShellwoodStation) };
+    public static Item Bellway__Bilewater => new PDBoolItem { Name = ItemNames.Bellway__Bilewater, BoolName = nameof(PlayerData.UnlockedShadowStation) };
+    public static Item Bellway__Putrified_Ducts => new PDBoolItem { Name = ItemNames.Bellway__Putrified_Ducts, BoolName = nameof(PlayerData.UnlockedAqueductStation) };
 
-    public static Item Ventrica__Choral_Chambers => new PDBoolItem { Name = ItemNames.Ventrica__Choral_Chambers, BoolName = "UnlockedSongTube" };
-    public static Item Ventrica__Underworks => new PDBoolItem { Name = ItemNames.Ventrica__Underworks, BoolName = "UnlockedUnderTube" };
-    public static Item Ventrica__Grand_Bellway => new PDBoolItem { Name = ItemNames.Ventrica__Grand_Bellway, BoolName = "UnlockedCityBellwayTube" };
-    public static Item Ventrica__High_Halls => new PDBoolItem { Name = ItemNames.Ventrica__High_Halls, BoolName = "UnlockedHangTube" };
-    public static Item Ventrica__First_Shrine => new PDBoolItem { Name = ItemNames.Ventrica__First_Shrine, BoolName = "UnlockedEnclaveTube" };
-    public static Item Ventrica__Memorium => new PDBoolItem { Name = ItemNames.Ventrica__Memorium, BoolName = "UnlockedArboriumTube" };
+    public static Item Ventrica__Choral_Chambers => new PDBoolItem { Name = ItemNames.Ventrica__Choral_Chambers, BoolName = nameof(PlayerData.UnlockedSongTube) };
+    public static Item Ventrica__Underworks => new PDBoolItem { Name = ItemNames.Ventrica__Underworks, BoolName = nameof(PlayerData.UnlockedUnderTube) };
+    public static Item Ventrica__Grand_Bellway => new PDBoolItem { Name = ItemNames.Ventrica__Grand_Bellway, BoolName = nameof(PlayerData.UnlockedCityBellwayTube) };
+    public static Item Ventrica__High_Halls => new PDBoolItem { Name = ItemNames.Ventrica__High_Halls, BoolName = nameof(PlayerData.UnlockedHangTube) };
+    public static Item Ventrica__First_Shrine => new PDBoolItem { Name = ItemNames.Ventrica__First_Shrine, BoolName = nameof(PlayerData.UnlockedEnclaveTube) };
+    public static Item Ventrica__Memorium => new PDBoolItem { Name = ItemNames.Ventrica__Memorium, BoolName = nameof(PlayerData.UnlockedArboriumTube) };
 
     public static Dictionary<string, Item> GetBaseItems()
     {


### PR DESCRIPTION
fixes https://github.com/homothetyhk/ItemChanger.Silksong/issues/38

Added 16 fast travel warp items (10 Bellway stations + 6 Ventrica tubes) using `PlayerDataBoolItem`.
## Bellway Stations
| Item Name | PlayerData Field |
|-----------|------------------|
| `Bellway__Deep_Docks` | `UnlockedDocksStation` |
| `Bellway__Far_Fields` | `UnlockedBoneforestEastStation` |
| `Bellway__Greymoor` | `UnlockedGreymoorStation` |
| `Bellway__Bellhart` | `UnlockedBelltownStation` |
| `Bellway__Blasted_Steps` | `UnlockedCoralTowerStation` |
| `Bellway__Grand_Bellway` | `UnlockedCityStation` |
| `Bellway__The_Slab` | `UnlockedPeakStation` |
| `Bellway__Shellwood` | `UnlockedShellwoodStation` |
| `Bellway__Bilewater` | `UnlockedShadowStation` |
| `Bellway__Putrified_Ducts` | `UnlockedAqueductStation` |
## Ventrica Tubes
| Item Name | PlayerData Field |
|-----------|------------------|
| `Ventrica__Choral_Chambers` | `UnlockedSongTube` |
| `Ventrica__Underworks` | `UnlockedUnderTube` |
| `Ventrica__Grand_Bellway` | `UnlockedCityBellwayTube` |
| `Ventrica__High_Halls` | `UnlockedHangTube` |
| `Ventrica__First_Shrine` | `UnlockedEnclaveTube` |
| `Ventrica__Memorium` | `UnlockedArboriumTube` |

## Notes
- `Bone_Bottom` and `The_Marrow` are unlocked by default (no items needed)
- `Terminus` is always unlocked (no item needed)
- All mappings were manually verified 
