### PR TITLE
Base game sprites

### DIFF
--- a/ItemChanger.Silksong/ItemChangerPlugin.cs
+++ b/ItemChanger.Silksong/ItemChangerPlugin.cs
@@ -1,5 +1,6 @@
 using BepInEx;
 using ItemChanger.Silksong.Containers;
+using ItemChanger.Silksong.Serialization;
 
 namespace ItemChanger.Silksong
 {
@@ -37,6 +38,7 @@ namespace ItemChanger.Silksong
             try
             {
                 DefineContainers();
+                AtlasSpriteBundleRegistry.Hook(ItemChangerHost.Singleton);
             }
             catch (Exception e)
             {

--- a/ItemChanger.Silksong/Serialization/AtlasSprite.cs
+++ b/ItemChanger.Silksong/Serialization/AtlasSprite.cs
@@ -1,0 +1,143 @@
+﻿using ItemChanger.Serialization;
+using Newtonsoft.Json;
+using Silksong.AssetHelper.Core;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceProviders;
+using UnityEngine.U2D;
+
+namespace ItemChanger.Silksong.Serialization;
+
+public static class AtlasSpriteBundleRegistry
+{
+    private static readonly HashSet<string> _bundleNames = [];
+
+    private static readonly Dictionary<string, AsyncOperationHandle<IAssetBundleResource>> _bundleHandles = [];
+
+    private static bool _loaded = false;
+
+    public static void RegisterBundle(string bundleName)
+    {
+        _bundleNames.Add(bundleName);
+
+        if (_loaded && !_bundleHandles.ContainsKey(bundleName))
+        {
+            _bundleHandles.Add(bundleName, LoadOne(bundleName));
+        }
+    }
+
+    public static AssetBundle RetrieveBundle(string bundleName)
+    {
+        if (!_loaded)
+        {
+            throw new InvalidOperationException("Cannot retrieve bundles while not loaded!");
+        }
+
+        AsyncOperationHandle<IAssetBundleResource> handle = _bundleHandles[bundleName];
+        if (!handle.IsDone)
+        {
+            handle.WaitForCompletion();
+        }
+
+        return handle.Result.GetAssetBundle();
+    }
+
+    private static AsyncOperationHandle<IAssetBundleResource> LoadOne(string bundleName)
+    {
+        string bundleKey = AddressablesData.ToBundleKey(bundleName);
+        return Addressables.LoadAssetAsync<IAssetBundleResource>(bundleKey);
+    }
+
+    private static void LoadAll()
+    {
+        if (_loaded)
+        {
+            ItemChangerPlugin.Instance.Logger.LogWarning($"{nameof(AtlasSpriteBundleRegistry)}.{nameof(LoadAll)} called multiple times!");
+            return;
+        }
+
+        foreach (string bundle in _bundleNames)
+        {
+            _bundleHandles[bundle] = LoadOne(bundle);
+        }
+        _loaded = true;
+    }
+
+    private static void UnloadAll()
+    {
+        foreach (AsyncOperationHandle<IAssetBundleResource> handle in _bundleHandles.Values)
+        {
+            Addressables.Release(handle);
+        }
+
+        _bundleHandles.Clear();
+        _loaded = false;
+    }
+
+    internal static void Hook(ItemChangerHost host)
+    {
+        host.LifecycleEvents.OnEnterGame += LoadAll;
+        host.LifecycleEvents.OnLeaveGame += UnloadAll;
+    }
+}
+
+/// <summary>
+/// Sprite provider which loads a sprite from a sprite atlas in one of the base game bundles.
+/// </summary>
+public class AtlasSprite : IValueProvider<Sprite>
+{
+    /// <summary>
+    /// The path to the asset bundle, with forward slashes separating directories and ending ".bundle".
+    /// 
+    /// For example, "atlases_assets_assets/sprites/_atlases/fayforn_after_sit.spriteatlas.bundle".
+    /// </summary>
+    public required string BundleName
+    {
+        get => field;
+        set
+        {
+            field = value;
+            AtlasSpriteBundleRegistry.RegisterBundle(value);
+        }
+    }
+
+    /// <summary>
+    /// The name of the SpriteAtlas within the bundle. This can be "Assets/Sprites/_Atlases/Fayforn_after_sit.spriteatlas"
+    /// </summary>
+    public string? AtlasName { get; init; }
+
+    public required string SpriteName { get; init; }
+
+    [JsonIgnore]
+    public Sprite Value
+    {
+        get
+        {
+            AssetBundle bundle = AtlasSpriteBundleRegistry.RetrieveBundle(BundleName);
+
+            string atlasName;
+            if (AtlasName != null)
+            {
+                atlasName = AtlasName;
+            }
+            else
+            {
+                string[] names = bundle.GetAllAssetNames();
+                if (names.Length == 1)
+                {
+                    atlasName = names[0];
+                }
+                else
+                {
+                    throw new ArgumentException($"Found {names.Length} assets in the bundle {BundleName}! The asset name must be specified.");
+                }
+            }
+            
+            SpriteAtlas atlas = bundle.LoadAsset<SpriteAtlas>(atlasName);
+            Sprite sprite = atlas.GetSprite(SpriteName);
+
+            return sprite;
+        }
+    }
+}

--- a/ItemChangerTesting/Tests.cs
+++ b/ItemChangerTesting/Tests.cs
@@ -6,9 +6,11 @@ using ItemChanger.Placements;
 using ItemChanger.Serialization;
 using ItemChanger.Silksong.Modules;
 using ItemChanger.Silksong.RawData;
+using ItemChanger.Silksong.Serialization;
 using ItemChanger.Silksong.StartDefs;
 using ItemChanger.Silksong.UIDefs;
 using System.ComponentModel;
+using UnityEngine;
 
 namespace ItemChangerTesting;
 
@@ -77,6 +79,9 @@ public enum Tests
     FleaAtFlea,
     [Description("Tests modifying the Pale_Oil-Whispering_Vaults shiny in-place")]
     Surgeon_s_Key_at_Whispering_Vaults,
+
+    [Description("Tests atlas sprites")]
+    AtlasSpriteItems,
 }
 
 public static class TestDispatcher
@@ -548,18 +553,38 @@ public static class TestDispatcher
                 prof.AddPlacement(finder.GetLocation(LocationNames.Pale_Oil__Whispering_Vaults)!
                     .Wrap().Add(finder.GetItem(ItemNames.Surgeon_s_Key)!));
                 break;
+
+            case Tests.AtlasSpriteItems:
+                StartNear(SceneNames.Tut_02, PrimitiveGateNames.right1);
+                prof.AddPlacement(new CoordinateLocation
+                {
+                    Name = "Plasmium",
+                    SceneName = SceneNames.Tut_02,
+                    X = 133.6f,
+                    Y = 31.57f,
+                    FlingType = ItemChanger.Enums.FlingType.Everywhere,
+                    Managed = false,
+                    ForceDefaultContainer = true,  // Multi shiny because chests aren't implemented
+                }.Wrap()
+                 .WithDebugItem(sprite: new AtlasSprite() { BundleName = "atlases_assets_assets/sprites/_atlases/hornet_map.spriteatlas", SpriteName = "pin_tube_station" }, text: "Ventrica")
+                 .WithDebugItem(sprite: new AtlasSprite() { BundleName = "atlases_assets_assets/sprites/_atlases/inventory.spriteatlas", SpriteName = "I_crimson_cloak_down" }, text: "DJ without glide")
+                 .WithDebugItem(sprite: new AtlasSprite() { BundleName = "atlases_assets_assets/sprites/_atlases/inventory.spriteatlas", SpriteName = "S_thread_dash" }, text: "Sharpdart?")
+                 .WithDebugItem(sprite: new AtlasSprite() { BundleName = "atlases_assets_assets/sprites/_atlases/inventory.spriteatlas", SpriteName = "Inv_0029_spell_core_outer_icons_0000_1_wall_jump" }, text: "claw")
+                 );
+                break;
+
         }
         Run();
     }
 
-    private static Placement WithDebugItem(this Placement self)
+    private static Placement WithDebugItem(this Placement self, IValueProvider<Sprite>? sprite = null, string? text = null)
         => self.Add(new DebugItem()
         {
             Name = $"Debug Item @ {self.Name}",
             UIDef = new MsgUIDef()
             {
-                Name = new BoxedString($"Checked {self.Name}"),
-                Sprite = new EmptySprite(),
+                Name = new BoxedString(text ?? $"Checked {self.Name}"),
+                Sprite = sprite ?? new EmptySprite(),
             }
         });
 }


### PR DESCRIPTION
Result of the test:

<img width="333" height="355" alt="image" src="https://github.com/user-attachments/assets/1106a9ee-73ed-4253-8aa6-c54e3b99cbcd" />

UABEANext is recommended for getting the sprite names, and AssetHelperMenu[Dump asset names] to check that there is indeed only one asset inside the bundle (although I believe that is the case for all the base game sprite atlas bundles). 

This could be done with AssetHelper directly (create a managed asset, etc) but the sprite bundles have no dependencies so it loosens the timing requirements to do it like this.