### PR TITLE
Make crest item popups have the right size and text

### DIFF
--- a/ItemChanger.Silksong/Items/ItemChangerSavedItem.cs
+++ b/ItemChanger.Silksong/Items/ItemChangerSavedItem.cs
@@ -1,4 +1,5 @@
 ﻿using ItemChanger.Items;
+using ItemChanger.Serialization;
 using ItemChanger.Silksong.Serialization;
 using ItemChanger.Silksong.UIDefs;
 
@@ -41,6 +42,24 @@ public class ItemChangerSavedItem : Item
         BaseGameSavedItem item = new() { Id = id, Type = type };
         return new() { Name = name, Item = item, PlayerDataBoolName = playerDataBoolName, UIDef = new SavedItemUIDef { Item = item } };
     }
+
+    public static ItemChangerSavedItem CreateWithMsgUIDef(string name, string id, BaseGameSavedItem.ItemType type, string nameSheet, string nameKey, float spriteScale)
+    {
+        BaseGameSavedItem item = new() { Id = id, Type = type };
+        return new() {
+            Name = name,
+            Item = item,
+            UIDef = new MsgUIDef
+            {
+                Name = new LanguageString(nameSheet, nameKey),
+                Sprite = new SavedItemSprite { Item = item },
+                SpriteScale = spriteScale,
+            },
+        };
+    }
+
+    public static ItemChangerSavedItem CreateCrest(string name, string id, string nameKey) =>
+        CreateWithMsgUIDef(name, id, BaseGameSavedItem.ItemType.ToolCrest, $"Mods.{ItemChangerPlugin.Id}", nameKey, 1f / 3);
 
     /* reference implementation for CollectableItem - not fully tested
     

--- a/ItemChanger.Silksong/RawData/BaseItemList/SkillsAbilitiesCrests.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/SkillsAbilitiesCrests.cs
@@ -63,50 +63,50 @@ internal static partial class BaseItemList
     // rem: needle strike also sets InvNailHasNew, InvPaneHasNew
 
     // crests
-    public static Item Crest_of_Architect => ItemChangerSavedItem.Create(
+    public static Item Crest_of_Architect => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Architect,
         id: "Toolmaster",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Beast => ItemChangerSavedItem.Create(
+        nameKey: "CREST_ARCHITECT_NAME");
+    public static Item Crest_of_Beast => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Beast,
         id: "Warrior",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Hunter => ItemChangerSavedItem.Create(
+        nameKey: "CREST_BEAST_NAME");
+    public static Item Crest_of_Hunter => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Hunter,
         id: "Hunter",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Hunter__Upgrade_1 => ItemChangerSavedItem.Create(
+        nameKey: "CREST_HUNTER_NAME");
+    public static Item Crest_of_Hunter__Upgrade_1 => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Hunter__Upgrade_1,
         id: "Hunter_v2",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Hunter__Upgrade_2 => ItemChangerSavedItem.Create(
+        nameKey: "CREST_HUNTER_V2_NAME");
+    public static Item Crest_of_Hunter__Upgrade_2 => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Hunter__Upgrade_2,
         id: "Hunter_v3",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Reaper => ItemChangerSavedItem.Create(
+        nameKey: "CREST_HUNTER_V3_NAME");
+    public static Item Crest_of_Reaper => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Reaper,
         id: "Reaper",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Shaman => ItemChangerSavedItem.Create(
+        nameKey: "CREST_REAPER_NAME");
+    public static Item Crest_of_Shaman => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Shaman,
         id: "Spell",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Wanderer => ItemChangerSavedItem.Create(
+        nameKey: "CREST_SHAMAN_NAME");
+    public static Item Crest_of_Wanderer => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Wanderer,
         id: "Wanderer",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Witch => ItemChangerSavedItem.Create(
+        nameKey: "CREST_WANDERER_NAME");
+    public static Item Crest_of_Witch => ItemChangerSavedItem.CreateCrest(
         name: ItemNames.Crest_of_Witch,
         id: "Witch",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Cursed_Witch => ItemChangerSavedItem.Create(
+        nameKey: "CREST_WITCH_NAME");
+    public static Item Crest_of_Cursed_Witch => ItemChangerSavedItem.CreateCrest(//not sure to include
         name: ItemNames.Crest_of_Cursed_Witch,
         id: "Cursed",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
-    public static Item Crest_of_Cloakless => ItemChangerSavedItem.Create(
+        nameKey: "CREST_CURSED_NAME");
+    public static Item Crest_of_Cloakless => ItemChangerSavedItem.CreateCrest(//not sure to include
         name: ItemNames.Crest_of_Cloakless,
         id: "Cloakless",
-        type: BaseGameSavedItem.ItemType.ToolCrest);
+        nameKey: "CREST_CLOAKLESS_NAME");
     public static Item Vesticrest_Blue => new PDBoolItem { Name = ItemNames.Vesticrest_Blue, BoolName = nameof(PlayerData.UnlockedExtraBlueSlot), UIDef = null! };
     public static Item Vesticrest_Yellow => new PDBoolItem { Name = ItemNames.Vesticrest_Yellow, BoolName = nameof(PlayerData.UnlockedExtraYellowSlot), UIDef = null! };
 }

--- a/ItemChanger.Silksong/Resources/Languages/default.json
+++ b/ItemChanger.Silksong/Resources/Languages/default.json
@@ -20,5 +20,17 @@
   "INV_NAME_RIGHTSLASH": "Rightslash",
   "INV_NAME_UPSLASH": "Upslash",
   "INV_NAME_DOWNSLASH": "Downslash",
-  "INV_DESC_ANYSLASH": "TODO"
+  "INV_DESC_ANYSLASH": "TODO",
+
+  "CREST_HUNTER_NAME": "Crest of Hunter",
+  "CREST_HUNTER_V2_NAME": "Crest of Hunter Level 2",
+  "CREST_HUNTER_V3_NAME": "Crest of Hunter Level 3",
+  "CREST_BEAST_NAME": "Crest of Beast",
+  "CREST_ARCHITECT_NAME": "Crest of Architect",
+  "CREST_REAPER_NAME": "Crest of Reaper",
+  "CREST_SHAMAN_NAME": "Crest of Shaman",
+  "CREST_WANDERER_NAME": "Crest of Wanderer",
+  "CREST_WITCH_NAME": "Crest of Witch",
+  "CREST_CURSED_NAME": "Crest of Cursed Witch",
+  "CREST_CLOAKLESS_NAME": "Crest of Cloakless"
 }

--- a/ItemChanger.Silksong/UIDefs/MsgUIDef.cs
+++ b/ItemChanger.Silksong/UIDefs/MsgUIDef.cs
@@ -13,6 +13,7 @@ namespace ItemChanger.Silksong.UIDefs
         public required IValueProvider<string> Name { get; init; }
         public IValueProvider<string>? ShopDesc { get; init; }
         public required IValueProvider<Sprite> Sprite { get; init; }
+        public float SpriteScale { get; init; } = 1f;
 
         /// <summary>
         /// Optional string to use as the preview name. If not given, will use the default implementation,
@@ -49,7 +50,7 @@ namespace ItemChanger.Silksong.UIDefs
         {
             if (type.HasFlag(MessageType.SmallPopup))
             {
-                MessageUtil.EnqueueMessage(Name.Value, Sprite?.Value);
+                MessageUtil.EnqueueMessage(Name.Value, Sprite?.Value, null, SpriteScale);
             }
             callback?.Invoke();
         }

--- a/ItemChanger.Silksong/Util/MessageUtil.cs
+++ b/ItemChanger.Silksong/Util/MessageUtil.cs
@@ -15,9 +15,9 @@ public static class MessageUtil
 {
     private static readonly Queue<ColorMsg> messages = [];
 
-    public static void EnqueueMessage(string text, Sprite? sprite = null, Color? modifyTextColor = null)
+    public static void EnqueueMessage(string text, Sprite? sprite = null, Color? modifyTextColor = null, float? spriteScale = null)
     {
-        messages.Enqueue(new(new ICMsg(text, sprite ?? SpriteUtil.Empty), modifyTextColor ?? Color.white));
+        messages.Enqueue(new(new ICMsg(text, sprite ?? SpriteUtil.Empty, spriteScale ?? 1f), modifyTextColor ?? Color.white));
     }
 
     public static void EnqueueMessage(ICollectableUIMsgItem msg, Color? modifyTextColor = null)
@@ -87,17 +87,18 @@ public static class MessageUtil
         public Color Color { get; } = color;
     }
 
-    private class ICMsg(string message, Sprite sprite) : ICollectableUIMsgItem
+    private class ICMsg(string message, Sprite sprite, float spriteScale) : ICollectableUIMsgItem
     {
         public string Message { get; } = message;
         public Sprite Sprite { get; } = sprite;
+        public float SpriteScale { get; } = spriteScale;
 
         public UObject GetRepresentingObject()
         {
             return MessageController.Instance;
         }
 
-        public float GetUIMsgIconScale() => 1f;
+        public float GetUIMsgIconScale() => SpriteScale;
 
         public string GetUIMsgName() => Message;
 


### PR DESCRIPTION
There's still no icon for the Cloakless Crest, but I don't even know what icon that should have.

For reference, this is what the Hunter crest popup looks like now:
<img width="1439" height="825" alt="hunter at wanderer" src="https://github.com/user-attachments/assets/88be9922-4512-4992-9a6f-d5b9e09d8d60" />

Fixes #64 

