### PR TITLE
Add Grounded Sprint novelty item

### DIFF
--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -59,7 +59,7 @@ public class GroundedSprintModule : CustomSkillModule
         if (!InputHandler.Instance.inputActions.Dash.IsPressed) return;
 
         Rigidbody2D rb = __instance.GetComponent<Rigidbody2D>();
-        if (rb == null) return;
+        if (rb == null || rb.bodyType == RigidbodyType2D.Static) return;
 
         float dir = __instance.cState.facingRight ? 1f : -1f;
         rb.velocity = new Vector2(dir * __instance.DASH_SPEED, rb.velocity.y);

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -1,0 +1,67 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace ItemChanger.Silksong.Modules.CustomSkills;
+
+public class GroundedSprintModule : CustomSkillModule
+{
+    public static GroundedSprintModule Instance { get; private set; }
+
+    private HarmonyLib.Harmony _harmony;
+
+#pragma warning disable IDE1006
+    public bool hasGroundedSprint { get; set; }
+#pragma warning restore IDE1006
+
+    public override IEnumerable<string> GettableSkillBools() => [nameof(hasGroundedSprint)];
+    public override bool GetBool(string boolName) => boolName switch
+    {
+        nameof(hasGroundedSprint) => hasGroundedSprint,
+        _ => throw UnsupportedBoolName(boolName),
+    };
+    public override IEnumerable<string> SettableSkillBools() => [nameof(hasGroundedSprint)];
+    public override void SetBool(string boolName, bool value)
+    {
+        switch (boolName)
+        {
+            case nameof(hasGroundedSprint):
+                hasGroundedSprint = value;
+                break;
+            default:
+                throw UnsupportedBoolName(boolName);
+        }
+    }
+
+    protected override void DoLoad()
+    {
+        base.DoLoad();
+        Instance = this;
+        _harmony = new HarmonyLib.Harmony("ItemChanger.Silksong.GroundedSprint");
+        _harmony.Patch(
+            AccessTools.Method(typeof(HeroController), nameof(HeroController.Move)),
+            postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(ApplyGroundSprint))
+        );
+    }
+
+    protected override void DoUnload()
+    {
+        base.DoUnload();
+        _harmony?.UnpatchSelf();
+        _harmony = null;
+        if (Instance == this) Instance = null;
+    }
+
+    private static void ApplyGroundSprint(HeroController __instance)
+    {
+        if (Instance == null || !Instance.hasGroundedSprint) return;
+        if (PlayerData.instance.hasDash) return;
+        if (!__instance.cState.onGround) return;
+        if (!InputHandler.Instance.inputActions.Dash.IsPressed) return;
+
+        Rigidbody2D rb = __instance.GetComponent<Rigidbody2D>();
+        if (rb == null) return;
+
+        float dir = __instance.cState.facingRight ? 1f : -1f;
+        rb.velocity = new Vector2(dir * __instance.DASH_SPEED, rb.velocity.y);
+    }
+}

--- a/ItemChanger.Silksong/RawData/BaseItemList/Novelties.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/Novelties.cs
@@ -1,7 +1,9 @@
 ﻿using ItemChanger.Items;
+using ItemChanger.Serialization;
 using ItemChanger.Silksong.Items;
 using ItemChanger.Silksong.Modules.CustomSkills;
 using ItemChanger.Silksong.UIDefs;
+using ItemChanger.Tags;
 
 namespace ItemChanger.Silksong.RawData;
 
@@ -154,4 +156,26 @@ internal partial class BaseItemList
     public static Item Double_Mask_Shard => new MaskShardItem { Name = ItemNames.Double_Mask_Shard, Shards = 2, UIDef = null! };
     public static Item Full_Mask => new MaskShardItem { Name = ItemNames.Full_Mask, Shards = 4, UIDef = null! };
     public static Item Full_Spool => new SpoolFragmentItem { Name = ItemNames.Full_Spool, Fragments = 2, UIDef = null! };
+
+    // Grounded Sprint → Swift Step progression
+    public static Item Grounded_Sprint_Item => WithChainTag(
+        new CustomSkillItem
+        {
+            Name = ItemNames.Grounded_Sprint,
+            BoolName = nameof(GroundedSprintModule.hasGroundedSprint),
+            ModuleTypeName = typeof(GroundedSprintModule).FullName,
+            UIDef = new MsgUIDef
+            {
+                Name = new BoxedString("Grounded Sprint"),
+                ShopDesc = new BoxedString("Allows sprinting while grounded. Midair speed is capped to walking speed."),
+                Sprite = null!,
+            },
+        },
+        successor: ItemNames.Swift_Step);
+
+    private static T WithChainTag<T>(T item, string? predecessor = null, string? successor = null) where T : Item
+    {
+        item.AddTag(new ItemChainTag { Predecessor = predecessor, Successor = successor });
+        return item;
+    }
 }

--- a/ItemChanger.Silksong/RawData/ItemNames.cs
+++ b/ItemChanger.Silksong/RawData/ItemNames.cs
@@ -425,6 +425,7 @@ public static class ItemNames
     public const string Double_Mask_Shard = "Double_Mask_Shard";
     public const string Full_Mask = "Full_Mask";
     public const string Full_Spool = "Full_Spool";
+    public const string Grounded_Sprint = "Grounded_Sprint";
 
     // Flea
     public const string Flea = "Flea";

--- a/ItemChangerTesting/ItemTests/GroundedSprintTest.cs
+++ b/ItemChangerTesting/ItemTests/GroundedSprintTest.cs
@@ -1,0 +1,40 @@
+using Benchwarp.Data;
+using ItemChanger;
+using ItemChanger.Locations;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChangerTesting.ItemTests;
+
+internal class GroundedSprintTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.ItemTests,
+        MenuName = "Grounded Sprint",
+        MenuDescription = "Tests Grounded Sprint → Swift Step chain progression from coordinate shinies.",
+        Revision = 2026030900,
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Tut_02, PrimitiveGateNames.right1);
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Grounded Sprint (1st pickup)",
+            SceneName = SceneNames.Tut_02,
+            X = 130.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Grounded_Sprint)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Swift Step via chain (2nd pickup)",
+            SceneName = SceneNames.Tut_02,
+            X = 136.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Grounded_Sprint)!));
+    }
+}


### PR DESCRIPTION
Adds a **Grounded Sprint** novelty item that gives sprint-only functionality (no dash) when on the ground, reading `DASH_SPEED` from `HeroController`.

## Changes
- **`GroundedSprintModule.cs`** (`CustomSkills/`): Listens for sprint input (`inputActions.Dash.IsPressed`) and boosts ground velocity to `DASH_SPEED` via `HeroController.Move` postfix.
- **`Novelties.cs`**: Registers `Grounded_Sprint` as a `CustomSkillItem` with `ItemChainTag` (successor: `Swift_Step`).
- **`ItemNames.cs`**: Added `Grounded_Sprint` constant.
- **`GroundedSprintTest.cs`**: Test placing Grounded Sprint twice; first pickup gives ground sprint, second auto-advances to Swift Step via chain.

## Progression
Grounded Sprint -> Swift Step via `ItemChainTag`. First pickup gives ground-only sprint (velocity boost when holding sprint key on ground). Second pickup advances to full Swift Step with dash.