### PR TITLE
implemented UIDefs for most bellhome and mapping items along with minor BaseLanguageStrings updates

### DIFF
--- a/ItemChanger.Silksong/RawData/BaseAtlasSprites/MappingItems.cs
+++ b/ItemChanger.Silksong/RawData/BaseAtlasSprites/MappingItems.cs
@@ -245,12 +245,7 @@ internal static partial class BaseAtlasSprites
         BundleName = "atlases_assets_assets/sprites/_atlases/hornet_map.spriteatlas",
         SpriteName = "pin_tube_station"
     };
-    public static AtlasSprite Flea_Findings_Icon => new()//variant for flea findings icon
-    {
-        BundleName = "atlases_assets_assets/sprites/_atlases/hornet_map.spriteatlas",
-        SpriteName = "pin_flea"
-    };
-    public static AtlasSprite Flea_Findings_Icon_2 => new()//other variant for flea findings icon
+    public static AtlasSprite Flea_Findings_Icon => new()
     {
         BundleName = "atlases_assets_assets/sprites/_atlases/hornet_map.spriteatlas",
         SpriteName = "pin_grub_location"

--- a/ItemChanger.Silksong/RawData/BaseItemList/Bellhome.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/Bellhome.cs
@@ -1,6 +1,7 @@
 ﻿using ItemChanger.Items;
 using ItemChanger.Silksong.Items;
 using ItemChanger.Silksong.Serialization;
+using ItemChanger.Silksong.UIDefs;
 
 namespace ItemChanger.Silksong.RawData;
 
@@ -20,15 +21,15 @@ internal static partial class BaseItemList
         id: "Materium",
         type: BaseGameSavedItem.ItemType.CollectableItem);
 
-    public static Item Desk => new PDBoolItem { Name = ItemNames.Desk, BoolName = nameof(PlayerData.BelltownFurnishingDesk), UIDef = null! };
-    public static Item Gleamlights => new PDBoolItem { Name = ItemNames.Gleamlights, BoolName = nameof(PlayerData.BelltownFurnishingFairyLights), UIDef = null! };
-    public static Item Gramophone => new PDBoolItem { Name = ItemNames.Gramophone, BoolName = nameof(PlayerData.BelltownFurnishingGramaphone), UIDef = null! };
-    public static Item Personal_Spa => new PDBoolItem { Name = ItemNames.Personal_Spa, BoolName = nameof(PlayerData.BelltownFurnishingSpa), UIDef = null! };
+    public static Item Desk => new PDBoolItem { Name = ItemNames.Desk, BoolName = nameof(PlayerData.BelltownFurnishingDesk), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Desk_Name, ShopDesc = BaseLanguageStrings.Desk_Desc, Sprite = BaseAtlasSprites.Desk } };
+    public static Item Gleamlights => new PDBoolItem { Name = ItemNames.Gleamlights, BoolName = nameof(PlayerData.BelltownFurnishingFairyLights), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Gleamlights_Name, ShopDesc = BaseLanguageStrings.Gleamlights_Desc, Sprite = BaseAtlasSprites.Gleamlights } };
+    public static Item Gramophone => new PDBoolItem { Name = ItemNames.Gramophone, BoolName = nameof(PlayerData.BelltownFurnishingGramaphone), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Gramophone_Name, ShopDesc = BaseLanguageStrings.Gramophone_Desc, Sprite = BaseAtlasSprites.Gramophone } };
+    public static Item Personal_Spa => new PDBoolItem { Name = ItemNames.Personal_Spa, BoolName = nameof(PlayerData.BelltownFurnishingSpa), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Personal_Spa_Name, ShopDesc = BaseLanguageStrings.Personal_Spa_Desc, Sprite = BaseAtlasSprites.Personal_Spa } };
 
-    public static Item Bell_Lacquer__Red => new PDIntItem { Name = ItemNames.Bell_Lacquer__Red, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 1, Increment = false, UIDef = null! };
-    public static Item Bell_Lacquer__White => new PDIntItem { Name = ItemNames.Bell_Lacquer__White, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 2, Increment = false, UIDef = null! };
-    public static Item Bell_Lacquer__Black => new PDIntItem { Name = ItemNames.Bell_Lacquer__Black, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 3, Increment = false, UIDef = null! };
-    public static Item Bell_Lacquer__Bronze => new PDIntItem { Name = ItemNames.Bell_Lacquer__Bronze, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 4, Increment = false, UIDef = null! };
-    public static Item Bell_Lacquer__Blue => new PDIntItem { Name = ItemNames.Bell_Lacquer__Blue, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 5, Increment = false, UIDef = null! };
-    public static Item Bell_Lacquer__Chrome => new PDIntItem { Name = ItemNames.Bell_Lacquer__Chrome, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 6, Increment = false, UIDef = null! };
+    public static Item Bell_Lacquer__Red => new PDIntItem { Name = ItemNames.Bell_Lacquer__Red, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 1, Increment = false, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bell_Lacquer_Name, ShopDesc = BaseLanguageStrings.Bell_Lacquer_Desc, Sprite = BaseAtlasSprites.Bell_Lacquer__Red } };
+    public static Item Bell_Lacquer__White => new PDIntItem { Name = ItemNames.Bell_Lacquer__White, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 2, Increment = false, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bell_Lacquer_Name, ShopDesc = BaseLanguageStrings.Bell_Lacquer_Desc, Sprite = BaseAtlasSprites.Bell_Lacquer__White } };
+    public static Item Bell_Lacquer__Black => new PDIntItem { Name = ItemNames.Bell_Lacquer__Black, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 3, Increment = false, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bell_Lacquer_Name, ShopDesc = BaseLanguageStrings.Bell_Lacquer_Desc, Sprite = BaseAtlasSprites.Bell_Lacquer__Black } };
+    public static Item Bell_Lacquer__Bronze => new PDIntItem { Name = ItemNames.Bell_Lacquer__Bronze, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 4, Increment = false, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bell_Lacquer_Name, ShopDesc = BaseLanguageStrings.Bell_Lacquer_Desc, Sprite = BaseAtlasSprites.Bell_Lacquer__Bronze } };
+    public static Item Bell_Lacquer__Blue => new PDIntItem { Name = ItemNames.Bell_Lacquer__Blue, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 5, Increment = false, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bell_Lacquer_Name, ShopDesc = BaseLanguageStrings.Bell_Lacquer_Desc, Sprite = BaseAtlasSprites.Bell_Lacquer__Blue } };
+    public static Item Bell_Lacquer__Chrome => new PDIntItem { Name = ItemNames.Bell_Lacquer__Chrome, IntName = nameof(PlayerData.BelltownHouseColour), Amount = 6, Increment = false, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bell_Lacquer_Name, ShopDesc = BaseLanguageStrings.Bell_Lacquer_Desc, Sprite = BaseAtlasSprites.Bell_Lacquer__Chrome } };
 }

--- a/ItemChanger.Silksong/RawData/BaseItemList/KeysEquipmentUpgrades.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/KeysEquipmentUpgrades.cs
@@ -1,6 +1,7 @@
 ﻿using ItemChanger.Items;
 using ItemChanger.Silksong.Items;
 using ItemChanger.Silksong.Serialization;
+using ItemChanger.Silksong.UIDefs;
 
 namespace ItemChanger.Silksong.RawData;
 
@@ -12,10 +13,10 @@ internal static partial class BaseItemList
      */
     //TODO: extend ItemChangerCollectableItem class to support separate values for crafting kit and tool pouch
 
-    public static Item Silk_Heart => new PDIntItem { Name = ItemNames.Silk_Heart, IntName = nameof(PlayerData.silkRegenMax), Amount = 1, Increment = true, UIDef = null! };
-    public static Item Mask_Shard => new MaskShardItem { Name = ItemNames.Mask_Shard, Shards = 1, UIDef = null! };
-    public static Item Spool_Fragment => new SpoolFragmentItem { Name = ItemNames.Spool_Fragment, Fragments = 1, UIDef = null! };
-    public static Item Hunter_s_Journal => new PDBoolItem { Name = ItemNames.Hunter_s_Journal, BoolName = nameof(PlayerData.hasJournal), };
+    public static Item Silk_Heart => new PDIntItem { Name = ItemNames.Silk_Heart, IntName = nameof(PlayerData.silkRegenMax), Amount = 1, Increment = true, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Silk_Heart_Name, ShopDesc = BaseLanguageStrings.Silk_Heart_Desc, Sprite = BaseAtlasSprites.Silk_Heart } };
+    public static Item Mask_Shard => new MaskShardItem { Name = ItemNames.Mask_Shard, Shards = 1, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Mask_Shard_Name, ShopDesc = BaseLanguageStrings.Mask_Shard_Desc, Sprite = BaseAtlasSprites.Mask_Shard } };
+    public static Item Spool_Fragment => new SpoolFragmentItem { Name = ItemNames.Spool_Fragment, Fragments = 1, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Spool_Fragment_Name, ShopDesc = BaseLanguageStrings.Spool_Fragment_Desc, Sprite = BaseAtlasSprites.Spool_Fragment } };
+    public static Item Hunter_s_Journal => new PDBoolItem { Name = ItemNames.Hunter_s_Journal, BoolName = nameof(PlayerData.hasJournal), UIDef = null! };
     public static Item Crafting_Kit => ItemChangerSavedItem.Create(//refers to same internal item as tool pouch
         name: ItemNames.Crafting_Kit,
         id: "Tool Pouch&Kit Inv",
@@ -43,13 +44,6 @@ internal static partial class BaseItemList
 
 
     //keys
-    /* note: all slab keys refer to the same internal CollectableItem Slab Key
-     * the slab keys have corresponding PLayerData bools
-        Key_of_Apostate -> HasSlabKeyC
-        Key_of_Heretic -> HasSlabKeyB
-        Key_of_Indolent -> HasSlabKeyA
-     */
-    //TODO: extend ItemChangerCollectibleItem class for the slab keys to support changing corresponding PlayerData bools for the different key types
     public static Item Architect_s_Key => ItemChangerSavedItem.Create(
         name: ItemNames.Architect_s_Key,
         id: "Architect Key",
@@ -69,15 +63,18 @@ internal static partial class BaseItemList
     public static Item Key_of_Apostate => ItemChangerSavedItem.Create(//refers to Slab Key; PlayerData bool HasSlabKeyC
         name: ItemNames.Key_of_Apostate,
         id: "Slab Key",
-        type: BaseGameSavedItem.ItemType.CollectableItem);
+        type: BaseGameSavedItem.ItemType.CollectableItem,
+        playerDataBoolName: nameof(PlayerData.HasSlabKeyC));
     public static Item Key_of_Heretic => ItemChangerSavedItem.Create(//refers to Slab Key; PlayerData bool HasSlabKeyB
         name: ItemNames.Key_of_Heretic,
         id: "Slab Key",
-        type: BaseGameSavedItem.ItemType.CollectableItem);
+        type: BaseGameSavedItem.ItemType.CollectableItem,
+        playerDataBoolName: nameof(PlayerData.HasSlabKeyB));
     public static Item Key_of_Indolent => ItemChangerSavedItem.Create(//refers to Slab Key; PlayerData bool HasSlabKeyA
         name: ItemNames.Key_of_Indolent,
         id: "Slab Key",
-        type: BaseGameSavedItem.ItemType.CollectableItem);
+        type: BaseGameSavedItem.ItemType.CollectableItem,
+        playerDataBoolName: nameof(PlayerData.HasSlabKeyA));
     public static Item Simple_Key => ItemChangerSavedItem.Create(
         name: ItemNames.Simple_Key,
         id: "Simple Key",

--- a/ItemChanger.Silksong/RawData/BaseItemList/MapsAndMappingItems.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/MapsAndMappingItems.cs
@@ -8,7 +8,7 @@ namespace ItemChanger.Silksong.RawData;
 internal static partial class BaseItemList
 {
     // maps
-    public static Item Bellhart_Map => new PDBoolItem { Name = ItemNames.Bellhart_Map, BoolName = nameof(PlayerData.HasBellhartMap), UIDef = null! };
+    public static Item Bellhart_Map => new PDBoolItem { Name = ItemNames.Bellhart_Map, BoolName = nameof(PlayerData.HasBellhartMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bellhart_Map_Name, ShopDesc = BaseLanguageStrings.Bellhart_Map_Desc, Sprite = BaseAtlasSprites.Bellhart_Map } };
     
     public static Item Bilewater_Map => new PDBoolItem
     {
@@ -22,56 +22,57 @@ internal static partial class BaseItemList
         }
     };
 
-    public static Item Blasted_Steps_Map => new PDBoolItem { Name = ItemNames.Blasted_Steps_Map, BoolName = nameof(PlayerData.HasJudgeStepsMap), UIDef = null! };
-    public static Item Choral_Chambers_Map => new PDBoolItem { Name = ItemNames.Choral_Chambers_Map, BoolName = nameof(PlayerData.HasHallsMap), UIDef = null! };
-    public static Item Cogwork_Core_Map => new PDBoolItem { Name = ItemNames.Cogwork_Core_Map, BoolName = nameof(PlayerData.HasCogMap), UIDef = null! };
-    public static Item Cradle_Map => new PDBoolItem { Name = ItemNames.Cradle_Map, BoolName = nameof(PlayerData.HasCradleMap), UIDef = null! };
-    public static Item Deep_Docks_Map => new PDBoolItem { Name = ItemNames.Deep_Docks_Map, BoolName = nameof(PlayerData.HasDocksMap), UIDef = null! };
-    public static Item Far_Fields_Map => new PDBoolItem { Name = ItemNames.Far_Fields_Map, BoolName = nameof(PlayerData.HasWildsMap), UIDef = null! };
-    public static Item Grand_Gate_Map => new PDBoolItem { Name = ItemNames.Grand_Gate_Map, BoolName = nameof(PlayerData.HasSongGateMap), UIDef = null! };
-    public static Item Greymoor_Map => new PDBoolItem { Name = ItemNames.Greymoor_Map, BoolName = nameof(PlayerData.HasGreymoorMap), UIDef = null! };
-    public static Item High_Halls_Map => new PDBoolItem { Name = ItemNames.High_Halls_Map, BoolName = nameof(PlayerData.HasHangMap), UIDef = null! };
-    public static Item Hunter_s_March_Map => new PDBoolItem { Name = ItemNames.Hunter_s_March_Map, BoolName = nameof(PlayerData.HasHuntersNestMap), UIDef = null! };
-    public static Item Memorium_Map => new PDBoolItem { Name = ItemNames.Memorium_Map, BoolName = nameof(PlayerData.HasArboriumMap), UIDef = null! };
-    public static Item Mosslands_Map => new PDBoolItem { Name = ItemNames.Mosslands_Map, BoolName = nameof(PlayerData.HasMossGrottoMap), UIDef = null! };
-    public static Item Mount_Fay_Map => new PDBoolItem { Name = ItemNames.Mount_Fay_Map, BoolName = nameof(PlayerData.HasPeakMap), UIDef = null! };
-    public static Item Putrified_Ducts_Map => new PDBoolItem { Name = ItemNames.Putrified_Ducts_Map, BoolName = nameof(PlayerData.HasAqueductMap), UIDef = null! };
-    public static Item Sands_of_Karak_Map => new PDBoolItem { Name = ItemNames.Sands_of_Karak_Map, BoolName = nameof(PlayerData.HasCoralMap), UIDef = null! };
-    public static Item Shellwood_Map => new PDBoolItem { Name = ItemNames.Shellwood_Map, BoolName = nameof(PlayerData.HasShellwoodMap), UIDef = null! };
-    public static Item Sinner_s_Road_Map => new PDBoolItem { Name = ItemNames.Sinner_s_Road_Map, BoolName = nameof(PlayerData.HasDustpensMap), UIDef = null! };
-    public static Item The_Abyss_Map => new PDBoolItem { Name = ItemNames.The_Abyss_Map, BoolName = nameof(PlayerData.HasAbyssMap), UIDef = null! };
-    public static Item The_Marrow_Map => new PDBoolItem { Name = ItemNames.The_Marrow_Map, BoolName = nameof(PlayerData.HasBoneforestMap), UIDef = null! };
-    public static Item The_Slab_Map => new PDBoolItem { Name = ItemNames.The_Slab_Map, BoolName = nameof(PlayerData.HasSlabMap), UIDef = null! };
-    public static Item Underworks_Map => new PDBoolItem { Name = ItemNames.Underworks_Map, BoolName = nameof(PlayerData.HasCitadelUnderstoreMap), UIDef = null! };
-    public static Item Verdania_Map => new PDBoolItem { Name = ItemNames.Verdania_Map, BoolName = nameof(PlayerData.HasCloverMap), UIDef = null! };
-    public static Item Weavenest_Alta_Map => new PDBoolItem { Name = ItemNames.Weavenest_Alta_Map, BoolName = nameof(PlayerData.HasWeavehomeMap), UIDef = null! };
-    public static Item Whispering_Vaults_Map => new PDBoolItem { Name = ItemNames.Whispering_Vaults_Map, BoolName = nameof(PlayerData.HasLibraryMap), UIDef = null! };
-    public static Item Whiteward_Map => new PDBoolItem { Name = ItemNames.Whiteward_Map, BoolName = nameof(PlayerData.HasWardMap), UIDef = null! };
-    public static Item Wormways_Map => new PDBoolItem { Name = ItemNames.Wormways_Map, BoolName = nameof(PlayerData.HasCrawlMap), UIDef = null! };
+    public static Item Blasted_Steps_Map => new PDBoolItem { Name = ItemNames.Blasted_Steps_Map, BoolName = nameof(PlayerData.HasJudgeStepsMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Blasted_Steps_Map_Name, ShopDesc = BaseLanguageStrings.Blasted_Steps_Map_Desc, Sprite = BaseAtlasSprites.Blasted_Steps_Map } };
+    public static Item Choral_Chambers_Map => new PDBoolItem { Name = ItemNames.Choral_Chambers_Map, BoolName = nameof(PlayerData.HasHallsMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Choral_Chambers_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Choral_Chambers_Map } };
+    public static Item Cogwork_Core_Map => new PDBoolItem { Name = ItemNames.Cogwork_Core_Map, BoolName = nameof(PlayerData.HasCogMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Cogwork_Core_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Cogwork_Core_Map } };
+    public static Item Cradle_Map => new PDBoolItem { Name = ItemNames.Cradle_Map, BoolName = nameof(PlayerData.HasCradleMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Cradle_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Cradle_Map } };
+    public static Item Deep_Docks_Map => new PDBoolItem { Name = ItemNames.Deep_Docks_Map, BoolName = nameof(PlayerData.HasDocksMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Deep_Docks_Map_Name, ShopDesc = BaseLanguageStrings.Deep_Docks_Map_Desc, Sprite = BaseAtlasSprites.Deep_Docks_Map } };
+    public static Item Far_Fields_Map => new PDBoolItem { Name = ItemNames.Far_Fields_Map, BoolName = nameof(PlayerData.HasWildsMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Far_Fields_Map_Name, ShopDesc = BaseLanguageStrings.Far_Fields_Map_Desc, Sprite = BaseAtlasSprites.Far_Fields_Map } };
+    public static Item Grand_Gate_Map => new PDBoolItem { Name = ItemNames.Grand_Gate_Map, BoolName = nameof(PlayerData.HasSongGateMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Grand_Gate_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Grand_Gate_Map } };
+    public static Item Greymoor_Map => new PDBoolItem { Name = ItemNames.Greymoor_Map, BoolName = nameof(PlayerData.HasGreymoorMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Greymoor_Map_Name, ShopDesc = BaseLanguageStrings.Greymoor_Map_Desc, Sprite = BaseAtlasSprites.Greymoor_Map } };
+    public static Item High_Halls_Map => new PDBoolItem { Name = ItemNames.High_Halls_Map, BoolName = nameof(PlayerData.HasHangMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.High_Halls_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.High_Halls_Map } };
+    public static Item Hunter_s_March_Map => new PDBoolItem { Name = ItemNames.Hunter_s_March_Map, BoolName = nameof(PlayerData.HasHuntersNestMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Hunter_s_March_Map_Name, ShopDesc = BaseLanguageStrings.Hunter_s_March_Map_Desc, Sprite = BaseAtlasSprites.Hunter_s_March_Map } };
+    public static Item Memorium_Map => new PDBoolItem { Name = ItemNames.Memorium_Map, BoolName = nameof(PlayerData.HasArboriumMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Memorium_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Memorium_Map } };
+    public static Item Mosslands_Map => new PDBoolItem { Name = ItemNames.Mosslands_Map, BoolName = nameof(PlayerData.HasMossGrottoMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Mosslands_Map_Name, ShopDesc = BaseLanguageStrings.Mosslands_Map_Desc, Sprite = BaseAtlasSprites.Mosslands_Map } };
+    public static Item Mount_Fay_Map => new PDBoolItem { Name = ItemNames.Mount_Fay_Map, BoolName = nameof(PlayerData.HasPeakMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Mount_Fay_Map_Name, ShopDesc = BaseLanguageStrings.Mount_Fay_Map_Desc, Sprite = BaseAtlasSprites.Mount_Fay_Map } };
+    public static Item Putrified_Ducts_Map => new PDBoolItem { Name = ItemNames.Putrified_Ducts_Map, BoolName = nameof(PlayerData.HasAqueductMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Putrified_Ducts_Map_Name, ShopDesc = BaseLanguageStrings.Putrified_Ducts_Map_Desc, Sprite = BaseAtlasSprites.Putrified_Ducts_Map } };
+    public static Item Sands_of_Karak_Map => new PDBoolItem { Name = ItemNames.Sands_of_Karak_Map, BoolName = nameof(PlayerData.HasCoralMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Sands_of_Karak_Map_Name, ShopDesc = BaseLanguageStrings.Sands_of_Karak_Map_Desc, Sprite = BaseAtlasSprites.Sands_of_Karak_Map } };
+    public static Item Shellwood_Map => new PDBoolItem { Name = ItemNames.Shellwood_Map, BoolName = nameof(PlayerData.HasShellwoodMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Shellwood_Map_Name, ShopDesc = BaseLanguageStrings.Shellwood_Map_Desc, Sprite = BaseAtlasSprites.Shellwood_Map } };
+    public static Item Sinner_s_Road_Map => new PDBoolItem { Name = ItemNames.Sinner_s_Road_Map, BoolName = nameof(PlayerData.HasDustpensMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Sinner_s_Road_Map_Name, ShopDesc = BaseLanguageStrings.Sinner_s_Road_Map_Desc, Sprite = BaseAtlasSprites.Sinner_s_Road_Map } };
+    public static Item The_Abyss_Map => new PDBoolItem { Name = ItemNames.The_Abyss_Map, BoolName = nameof(PlayerData.HasAbyssMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.The_Abyss_Map_Name, ShopDesc = BaseLanguageStrings.The_Abyss_Map_Desc, Sprite = BaseAtlasSprites.The_Abyss_Map } };
+    public static Item The_Marrow_Map => new PDBoolItem { Name = ItemNames.The_Marrow_Map, BoolName = nameof(PlayerData.HasBoneforestMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.The_Marrow_Map_Name, ShopDesc = BaseLanguageStrings.The_Marrow_Map_Desc, Sprite = BaseAtlasSprites.The_Marrow_Map } };
+    public static Item The_Slab_Map => new PDBoolItem { Name = ItemNames.The_Slab_Map, BoolName = nameof(PlayerData.HasSlabMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.The_Slab_Map_Name, ShopDesc = BaseLanguageStrings.The_Slab_Map_Desc, Sprite = BaseAtlasSprites.The_Slab_Map } };
+    public static Item Underworks_Map => new PDBoolItem { Name = ItemNames.Underworks_Map, BoolName = nameof(PlayerData.HasCitadelUnderstoreMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Underworks_Map_Name, ShopDesc = BaseLanguageStrings.Underworks_Map_Desc, Sprite = BaseAtlasSprites.Underworks_Map } };
+    public static Item Verdania_Map => new PDBoolItem { Name = ItemNames.Verdania_Map, BoolName = nameof(PlayerData.HasCloverMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Verdania_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Verdania_Map } };
+    public static Item Weavenest_Alta_Map => new PDBoolItem { Name = ItemNames.Weavenest_Alta_Map, BoolName = nameof(PlayerData.HasWeavehomeMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Weavenest_Alta_Map_Name, ShopDesc = BaseLanguageStrings.Weavenest_Alta_Map_Desc, Sprite = BaseAtlasSprites.Weavenest_Alta_Map } };
+    public static Item Whispering_Vaults_Map => new PDBoolItem { Name = ItemNames.Whispering_Vaults_Map, BoolName = nameof(PlayerData.HasLibraryMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Whispering_Vaults_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Whispering_Vaults_Map } };
+    public static Item Whiteward_Map => new PDBoolItem { Name = ItemNames.Whiteward_Map, BoolName = nameof(PlayerData.HasWardMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Whiteward_Map_Name, ShopDesc = null!, Sprite = BaseAtlasSprites.Whiteward_Map } };
+    public static Item Wormways_Map => new PDBoolItem { Name = ItemNames.Wormways_Map, BoolName = nameof(PlayerData.HasCrawlMap), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Wormways_Map_Name, ShopDesc = BaseLanguageStrings.Wormways_Map_Desc, Sprite = BaseAtlasSprites.Wormways_Map } };
 
     // quills
-    public static Item Quill__White => new QuillItem { Name = ItemNames.Quill__White, QuillState = 1, UIDef = null! };
-    public static Item Quill__Red => new QuillItem { Name = ItemNames.Quill__Red, QuillState = 2, UIDef = null! };
-    public static Item Quill__Purple => new QuillItem { Name = ItemNames.Quill__Purple, QuillState = 3, UIDef = null! };
+    public static Item Quill__White => new QuillItem { Name = ItemNames.Quill__White, QuillState = 1, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Quill_Name, ShopDesc = BaseLanguageStrings.Quill_Desc, Sprite = BaseAtlasSprites.Quill__White } };
+    public static Item Quill__Red => new QuillItem { Name = ItemNames.Quill__Red, QuillState = 2, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Quill_Name, ShopDesc = BaseLanguageStrings.Quill_Desc, Sprite = BaseAtlasSprites.Quill__Red } };
+    public static Item Quill__Purple => new QuillItem { Name = ItemNames.Quill__Purple, QuillState = 3, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Quill_Name, ShopDesc = BaseLanguageStrings.Quill_Desc, Sprite = BaseAtlasSprites.Quill__Purple } };
 
     // map markers
-    public static Item Shell_Marker => new MarkerItem { Name = ItemNames.Shell_Marker, BoolName = nameof(PlayerData.hasMarker_a), UIDef = null! };
-    public static Item Ring_Marker => new MarkerItem { Name = ItemNames.Ring_Marker, BoolName = nameof(PlayerData.hasMarker_b), UIDef = null! };
-    public static Item Hunt_Marker => new MarkerItem { Name = ItemNames.Hunt_Marker, BoolName = nameof(PlayerData.hasMarker_c), UIDef = null! };
-    public static Item Dark_Marker => new MarkerItem { Name = ItemNames.Dark_Marker, BoolName = nameof(PlayerData.hasMarker_d), UIDef = null! };
-    public static Item Bronze_Marker => new MarkerItem { Name = ItemNames.Bronze_Marker, BoolName = nameof(PlayerData.hasMarker_e), UIDef = null! };
+    public static Item Shell_Marker => new MarkerItem { Name = ItemNames.Shell_Marker, BoolName = nameof(PlayerData.hasMarker_a), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Shell_Marker_Name, ShopDesc = BaseLanguageStrings.Shell_Marker_Desc, Sprite = BaseAtlasSprites.Shell_Marker } };
+    public static Item Ring_Marker => new MarkerItem { Name = ItemNames.Ring_Marker, BoolName = nameof(PlayerData.hasMarker_b), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Ring_Marker_Name, ShopDesc = BaseLanguageStrings.Ring_Marker_Desc, Sprite = BaseAtlasSprites.Ring_Marker } };
+    public static Item Hunt_Marker => new MarkerItem { Name = ItemNames.Hunt_Marker, BoolName = nameof(PlayerData.hasMarker_c), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Hunt_Marker_Name, ShopDesc = BaseLanguageStrings.Hunt_Marker_Desc, Sprite = BaseAtlasSprites.Hunt_Marker } };
+    public static Item Dark_Marker => new MarkerItem { Name = ItemNames.Dark_Marker, BoolName = nameof(PlayerData.hasMarker_d), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Dark_Marker_Name, ShopDesc = BaseLanguageStrings.Dark_Marker_Desc, Sprite = BaseAtlasSprites.Dark_Marker } };
+    public static Item Bronze_Marker => new MarkerItem { Name = ItemNames.Bronze_Marker, BoolName = nameof(PlayerData.hasMarker_e), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bronze_Marker_Name, ShopDesc = BaseLanguageStrings.Bronze_Marker_Desc, Sprite = BaseAtlasSprites.Bronze_Marker } };
 
     // map pins
-    public static Item Bench_Pins => new PDBoolItem { Name = ItemNames.Bench_Pins, BoolName = nameof(PlayerData.hasPinBench), UIDef = null! };
-    public static Item Bellway_Pins => new PDBoolItem { Name = ItemNames.Bellway_Pins, BoolName = nameof(PlayerData.hasPinStag), UIDef = null! };
-    public static Item Vendor_Pins => new PDBoolItem { Name = ItemNames.Vendor_Pins, BoolName = nameof(PlayerData.hasPinShop), UIDef = null! };
-    public static Item Ventrica_Pins => new PDBoolItem { Name = ItemNames.Ventrica_Pins, BoolName = nameof(PlayerData.hasPinTube), UIDef = null! };
+    public static Item Bench_Pins => new PDBoolItem { Name = ItemNames.Bench_Pins, BoolName = nameof(PlayerData.hasPinBench), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bench_Pins_Name, ShopDesc = BaseLanguageStrings.Bench_Pins_Desc, Sprite = BaseAtlasSprites.Bench_Pins } };
+    public static Item Bellway_Pins => new PDBoolItem { Name = ItemNames.Bellway_Pins, BoolName = nameof(PlayerData.hasPinStag), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Bellway_Pins_Name, ShopDesc = BaseLanguageStrings.Bellway_Pins_Desc, Sprite = BaseAtlasSprites.Bellway_Pins } };
+    public static Item Vendor_Pins => new PDBoolItem { Name = ItemNames.Vendor_Pins, BoolName = nameof(PlayerData.hasPinShop), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Vendor_Pins_Name, ShopDesc = BaseLanguageStrings.Vendor_Pins_Desc, Sprite = BaseAtlasSprites.Vendor_Pins } };
+    public static Item Ventrica_Pins => new PDBoolItem { Name = ItemNames.Ventrica_Pins, BoolName = nameof(PlayerData.hasPinTube), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Ventrica_Pins_Name, ShopDesc = BaseLanguageStrings.Ventrica_Pins_Desc, Sprite = BaseAtlasSprites.Ventrica_Pins } };
 
     // flea findings
-    public static Item Flea_Findings__Bonelands => new PDBoolItem { Name = ItemNames.Flea_Findings__Bonelands, BoolName = nameof(PlayerData.hasPinFleaMarrowlands), UIDef = null! };
-    public static Item Flea_Findings__Midlands => new PDBoolItem { Name = ItemNames.Flea_Findings__Midlands, BoolName = nameof(PlayerData.hasPinFleaMidlands), UIDef = null! };
-    public static Item Flea_Findings__Blasted_Steps => new PDBoolItem { Name = ItemNames.Flea_Findings__Blasted_Steps, BoolName = nameof(PlayerData.hasPinFleaBlastedlands), UIDef = null! };
-    public static Item Flea_Findings__The_Citadel => new PDBoolItem { Name = ItemNames.Flea_Findings__The_Citadel, BoolName = nameof(PlayerData.hasPinFleaCitadel), UIDef = null! };
-    public static Item Flea_Findings__Mount_Fay => new PDBoolItem { Name = ItemNames.Flea_Findings__Mount_Fay, BoolName = nameof(PlayerData.hasPinFleaPeaklands), UIDef = null! };
-    public static Item Flea_Findings__Bilelands => new PDBoolItem { Name = ItemNames.Flea_Findings__Bilelands, BoolName = nameof(PlayerData.hasPinFleaMucklands), UIDef = null! };
+    //TODO: find better names and descriptions for flea findings (currently <flea finding location> : null)
+    public static Item Flea_Findings__Bonelands => new PDBoolItem { Name = ItemNames.Flea_Findings__Bonelands, BoolName = nameof(PlayerData.hasPinFleaMarrowlands), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Flea_Findings__Bonelands_Desc, ShopDesc = null!, Sprite = BaseAtlasSprites.Flea_Findings_Icon } };
+    public static Item Flea_Findings__Midlands => new PDBoolItem { Name = ItemNames.Flea_Findings__Midlands, BoolName = nameof(PlayerData.hasPinFleaMidlands), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Flea_Findings__Midlands_Desc, ShopDesc = null!, Sprite = BaseAtlasSprites.Flea_Findings_Icon } };
+    public static Item Flea_Findings__Blasted_Steps => new PDBoolItem { Name = ItemNames.Flea_Findings__Blasted_Steps, BoolName = nameof(PlayerData.hasPinFleaBlastedlands), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Flea_Findings__Blasted_Steps_Desc, ShopDesc = null!, Sprite = BaseAtlasSprites.Flea_Findings_Icon } };
+    public static Item Flea_Findings__The_Citadel => new PDBoolItem { Name = ItemNames.Flea_Findings__The_Citadel, BoolName = nameof(PlayerData.hasPinFleaCitadel), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Flea_Findings__The_Citadel_Desc, ShopDesc = null!, Sprite = BaseAtlasSprites.Flea_Findings_Icon } };
+    public static Item Flea_Findings__Mount_Fay => new PDBoolItem { Name = ItemNames.Flea_Findings__Mount_Fay, BoolName = nameof(PlayerData.hasPinFleaPeaklands), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Flea_Findings__Mount_Fay_Desc, ShopDesc = null!, Sprite = BaseAtlasSprites.Flea_Findings_Icon } };
+    public static Item Flea_Findings__Bilelands => new PDBoolItem { Name = ItemNames.Flea_Findings__Bilelands, BoolName = nameof(PlayerData.hasPinFleaMucklands), UIDef = new MsgUIDef { Name = BaseLanguageStrings.Flea_Findings__Bilelands_Desc, ShopDesc = null!, Sprite = BaseAtlasSprites.Flea_Findings_Icon } };
 }

--- a/ItemChanger.Silksong/RawData/BaseItemList/Novelties.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/Novelties.cs
@@ -151,7 +151,8 @@ internal partial class BaseItemList
     };
 
     // combined shards and fragments
-    public static Item Double_Mask_Shard => new MaskShardItem { Name = ItemNames.Double_Mask_Shard, Shards = 2, UIDef = null! };
-    public static Item Full_Mask => new MaskShardItem { Name = ItemNames.Full_Mask, Shards = 4, UIDef = null! };
-    public static Item Full_Spool => new SpoolFragmentItem { Name = ItemNames.Full_Spool, Fragments = 2, UIDef = null! };
+    //TODO: find fitting sprites
+    public static Item Double_Mask_Shard => new MaskShardItem { Name = ItemNames.Double_Mask_Shard, Shards = 2, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Mask_Shard_Multi_Name, ShopDesc = BaseLanguageStrings.Mask_Shard_Multi_Desc, Sprite = null! } };
+    public static Item Full_Mask => new MaskShardItem { Name = ItemNames.Full_Mask, Shards = 4, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Mask_Shard_Full_Name, ShopDesc = BaseLanguageStrings.Mask_Shard_Full_Desc, Sprite = null! } };
+    public static Item Full_Spool => new SpoolFragmentItem { Name = ItemNames.Full_Spool, Fragments = 2, UIDef = new MsgUIDef { Name = BaseLanguageStrings.Spool_Fragment_Full_Name, ShopDesc = BaseLanguageStrings.Spool_Fragment_Full_Desc, Sprite = null! } };
 }

--- a/ItemChanger.Silksong/RawData/BaseLanguageStrings/MappingItems.cs
+++ b/ItemChanger.Silksong/RawData/BaseLanguageStrings/MappingItems.cs
@@ -5,6 +5,15 @@ namespace ItemChanger.Silksong.RawData;
 internal static partial class BaseLanguageStrings
 {
 
+    //quills
+    //NOTE: the quill items share the same name and description regardless of color
+    public static LanguageString Quill_Name => new("UI", "INV_NAME_QUILL");
+    public static LanguageString Quill_Desc => new("UI", "INV_DESC_QUILL");
+    public static LanguageString Map_Name => new("UI", "INV_NAME_MAP");
+    public static LanguageString Map_Desc => new("UI", "INV_DESC_MAP");
+    public static LanguageString Map_and_Quill_Name => new("UI", "INV_NAME_MAPANDQUILL");
+    public static LanguageString Map_and_Quill_Desc => new("UI", "INV_DESC_MAPANDQUILL");
+
     //maps (shakra/non citadel map machines)
     public static LanguageString Bellhart_Map_Name => new("Wanderers", "MAPPER_ITEM_MAP_BELLHART_NAME");
     public static LanguageString Bellhart_Map_Desc => new("Wanderers", "MAPPER_ITEM_MAP_BELLHART_DESC");

--- a/ItemChanger.Silksong/RawData/BaseLanguageStrings/Upgrades.cs
+++ b/ItemChanger.Silksong/RawData/BaseLanguageStrings/Upgrades.cs
@@ -9,6 +9,8 @@ internal static partial class BaseLanguageStrings
     public static LanguageString Mask_Shard_Desc => new("UI", "INV_DESC_HEART_PIECE_1");
     public static LanguageString Mask_Shard_Multi_Name => new("UI", "INV_NAME_HEART_PIECE_MULT");
     public static LanguageString Mask_Shard_Multi_Desc => new("UI", "INV_DESC_HEART_PIECE_MULT");
+    public static LanguageString Mask_Shard_Full_Name => new("UI", "INV_NAME_HEART_PIECE_FULL");
+    public static LanguageString Mask_Shard_Full_Desc => new("UI", "INV_DESC_HEART_PIECE_FULL");
 
     //silk hearts
     public static LanguageString Silk_Heart_Name => new("Prompts", "MEMORY_MSG_TITLE_SILKHEART");

--- a/ItemChangerTesting/ItemTests/BellhomeItemsTest.cs
+++ b/ItemChangerTesting/ItemTests/BellhomeItemsTest.cs
@@ -1,0 +1,68 @@
+﻿using Benchwarp.Data;
+using ItemChanger.Locations;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChangerTesting.ItemTests;
+
+//tests PDIntItem for lacquers, PDBoolItem for desk, CollectableItem for crawbell
+internal class BellhomeItemsTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.ItemTests,
+        MenuName = "Bellhome Items",
+        MenuDescription = "Tests various Bellhome items. (red/blue/chrome lacquers, desk, crawbell)",
+        Revision = 2026031400,
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Tut_02, PrimitiveGateNames.right1);
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Red Lacquer",
+            SceneName = SceneNames.Tut_02,
+            X = 130.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Bell_Lacquer__Red)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Blue Lacquer",
+            SceneName = SceneNames.Tut_02,
+            X = 131.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Bell_Lacquer__Blue)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Chrome Lacquer",
+            SceneName = SceneNames.Tut_02,
+            X = 132.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Bell_Lacquer__Chrome)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Desk",
+            SceneName = SceneNames.Tut_02,
+            X = 134.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Desk)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Crawbell",
+            SceneName = SceneNames.Tut_02,
+            X = 136.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Crawbell)!));
+       
+    }
+}

--- a/ItemChangerTesting/ItemTests/MapItemsTest.cs
+++ b/ItemChangerTesting/ItemTests/MapItemsTest.cs
@@ -1,0 +1,94 @@
+﻿using Benchwarp.Data;
+using ItemChanger.Locations;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChangerTesting.ItemTests;
+
+//tests QuillItem for the quills, PDBoolItem for cradle map and bench pin and citadel flea findings, BilewaterMapSprite for bilewater map, MarkerItem for bronze marker, 
+internal class MapItemsTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.ItemTests,
+        MenuName = "Map Items",
+        MenuDescription = "Tests various map items. (quills, cradle map, bilewater map, bronze marker, bench pin, citadel flea findings)",
+        Revision = 2026031400,
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Tut_02, PrimitiveGateNames.right1);
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "White Quill",
+            SceneName = SceneNames.Tut_02,
+            X = 130.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Quill__White)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Red Quill",
+            SceneName = SceneNames.Tut_02,
+            X = 131.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Quill__Red)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Purple Quill",
+            SceneName = SceneNames.Tut_02,
+            X = 132.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Quill__Purple)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Cradle Map",
+            SceneName = SceneNames.Tut_02,
+            X = 134.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Cradle_Map)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Bilewater Map",
+            SceneName = SceneNames.Tut_02,
+            X = 136.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Bilewater_Map)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Bronze Marker",
+            SceneName = SceneNames.Tut_02,
+            X = 138.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Bronze_Marker)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Bench Pin",
+            SceneName = SceneNames.Tut_02,
+            X = 140.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Bench_Pins)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "Citadel Flea Findings",
+            SceneName = SceneNames.Tut_02,
+            X = 142.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Flea_Findings__The_Citadel)!));
+    }
+}


### PR DESCRIPTION
added UIDefs for most bellhome and mapping items based on the added BaseAtlasSprites and BaseLanguageStrings (tests are included for map items and bellhome items)

other additions/updates:
-added UIDefs for mask shards and spool fragments
-implemented corresponding PDBools for the slab keys -added LanguageStrings for quill and map, full mask shards -updated flea findings BaseAtlasSprite

todo/future notes:
-add UIDef for hunter journal (may require big ui) -find better fitting sprites for the novelty items -implement descriptions for the citadel maps
-implement better names/descriptions for the flea findings (currently area : null)

(closes https://github.com/homothetyhk/ItemChanger.Silksong/issues/93)