### PR TITLE
Fix CrestCorpseLocation breaking vanilla silk skills

### DIFF
--- a/ItemChanger.Silksong/Locations/CrestCorpseLocation.cs
+++ b/ItemChanger.Silksong/Locations/CrestCorpseLocation.cs
@@ -35,7 +35,6 @@ public class CrestCorpseLocation : AutoLocation
         FsmState crestChangeState = fsm.MustGetState("Crest Change");
         crestChangeState.RemoveActionsOfType<UnlockCrest>();
         crestChangeState.RemoveActionsOfType<AutoEquipCrestV2>();
-        crestChangeState.RemoveActionsOfType<ToolsActiveStateControlV2>();
         crestChangeState.InsertLambdaMethod(0, GiveAll);
 
         FsmState crestMsgState = fsm.MustGetState("Crest Msg");


### PR DESCRIPTION
The FSM edit was removing the action that set ToolItemManager.ActiveState back to Active, but not the ones that set it to Disabled. Removing those state changes doesn't appear to be actually required for the location to work correctly.

Closes #120 