### PR TITLE
Fix SetAccepted to accept the relevant quest

### DIFF
--- a/ItemChanger.Silksong/Extensions/QuestExtensions.cs
+++ b/ItemChanger.Silksong/Extensions/QuestExtensions.cs
@@ -14,7 +14,7 @@ public static class QuestExtensions
         public void SetAccepted()
         {
             QuestCompletionData.Completion c = quest.Completion;
-            c.HasBeenSeen = true;
+            c.IsAccepted = true;
             quest.Completion = c;
         }
 


### PR DESCRIPTION
This seems to be a copy-paste issue between `SetSeen` and `SetAccepted`.

I've verified the fix with the Yarnaby location test. Once corrected, the Infestation Operation quest appears in the inventory on load, where previously it did not.