### PR TITLE
Add ObjectLocations for world Mask Shards and Spool Fragments (#110)

### DIFF
--- a/ItemChanger.Silksong/Containers/ShinyContainer.cs
+++ b/ItemChanger.Silksong/Containers/ShinyContainer.cs
@@ -4,7 +4,9 @@ using ItemChanger.Extensions;
 using ItemChanger.Silksong.Extensions;
 using ItemChanger.Silksong.Tags;
 using Silksong.UnityHelper.Extensions;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using UnityEngine;
 
 namespace ItemChanger.Silksong.Containers;
@@ -158,6 +160,28 @@ public class ShinyContainer : Container
             shiny.fling = false;
             rb.bodyType = RigidbodyType2D.Kinematic;
             shiny.pickupAnim = CollectableItemPickup.PickupAnimations.Stand;
+            // FloatInPlace shinies are already static — the prefab's waitForStoppedMoving
+            // behavior (designed for flung shinies that need to land) would temporarily
+            // deactivate interactEvents and only re-enable it once the rigidbody velocity
+            // drops below 0.1. Since the body is kinematic (velocity always zero), this
+            // would re-enable after canPickupDelay — but we want immediate interactability.
+            // Disable waitForStoppedMoving and zero canPickupDelay so interactEvents
+            // is never suppressed and the shiny is pickable the moment it appears.
+            Type cipType = typeof(CollectableItemPickup);
+            cipType.GetField("waitForStoppedMoving", BindingFlags.NonPublic | BindingFlags.Instance)
+                   ?.SetValue(shiny, false);
+            cipType.GetField("canPickupDelay", BindingFlags.NonPublic | BindingFlags.Instance)
+                   ?.SetValue(shiny, 0f);
+
+            // Some Heart Piece / Silk Spool objects are parented to (or start inactive inside)
+            // a breakable container (e.g. Library_05 jar). ObjectLocation parents our
+            // replacement shiny to that same container and mirrors the Heart Piece's active
+            // state. If the Heart Piece was inactive, Unity cancels the shiny's Start()
+            // call when SetActive(false) is applied — so a Start()-based detach never runs.
+            // ShinyDetachScheduler uses a DontDestroyOnLoad MonoBehaviour whose LateUpdate
+            // fires reliably after sceneLoaded (when IC edits run) regardless of active state,
+            // detaching the shiny from the container and ensuring it is active.
+            ShinyDetachScheduler.Schedule(shiny.gameObject);
         }
         else
         {
@@ -234,5 +258,53 @@ public class ShinyContainer : Container
 
     protected override void DoUnload()
     {
+    }
+
+    /// <summary>
+    /// Schedules FloatInPlace shinies to be detached from their parent container and
+    /// activated after the current frame's scene edits complete.
+    ///
+    /// Why not Start(): IC's ApplyTargetContext can call SetActive(false) on the shiny
+    /// (mirroring an inactive Heart Piece inside a closed container). Unity cancels
+    /// pending Start() calls when an object is deactivated, so Start()-based detach
+    /// never runs. Using a persistent DontDestroyOnLoad MonoBehaviour's LateUpdate
+    /// guarantees execution after sceneLoaded + ApplyTargetContext, regardless of
+    /// the shiny's active state.
+    /// </summary>
+    private static class ShinyDetachScheduler
+    {
+        private static SchedulerBehaviour? _instance;
+
+        internal static void Schedule(GameObject go)
+        {
+            if (!_instance)
+            {
+                var host = new GameObject("IC_Silksong_ShinyDetach");
+                UnityEngine.Object.DontDestroyOnLoad(host);
+                _instance = host.AddComponent<SchedulerBehaviour>();
+            }
+            _instance!.Pending.Add(go);
+        }
+
+        private class SchedulerBehaviour : MonoBehaviour
+        {
+            internal readonly List<GameObject> Pending = new();
+
+            private void LateUpdate()
+            {
+                if (Pending.Count == 0) return;
+                foreach (var go in Pending)
+                {
+                    if (go == null) continue;
+                    // Detach from container so destroying the container doesn't destroy the shiny.
+                    go.transform.SetParent(null, worldPositionStays: true);
+                    // If the Heart Piece was inactive (hidden inside the container), activate
+                    // the shiny now so it's immediately contactable without opening the container.
+                    if (!go.activeSelf)
+                        go.SetActive(true);
+                }
+                Pending.Clear();
+            }
+        }
     }
 }

--- a/ItemChanger.Silksong/RawData/BaseLocationList.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList.cs
@@ -28,6 +28,20 @@ namespace ItemChanger.Silksong.RawData
             Tags = [new OriginalContainerTag() { ContainerType = ContainerNames.Shiny }]
         };
 
+        // Shared tag for non-CollectableItemPickup interactables (Heart Piece, Silk Spool, Silk Grub, etc.)
+        // IC replaces the object with a new shiny. ShinyType.Instant uses the contact-pickup prefab
+        // (same mechanic as mossberry drops), bypassing the interactEvents system which does not
+        // reliably detect the player for runtime-spawned shinies. FloatInPlace keeps the shiny
+        // stationary at the original object's position rather than letting it fall.
+        internal static ShinyControlTag FloatShiny => new()
+        {
+            Info = new ShinyContainer.ShinyControlInfo
+            {
+                ShinyType = ShinyContainer.ShinyType.Instant,
+                ShinyFling = ShinyContainer.ShinyFling.FloatInPlace,
+            }
+        };
+
         public static Dictionary<string, Location> GetBaseLocations()
         {
             return typeof(BaseLocationList).GetProperties().Select(p => (Location)p.GetValue(null)).ToDictionary(l => l.Name);

--- a/ItemChanger.Silksong/RawData/BaseLocationList/MaskShards.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/MaskShards.cs
@@ -1,0 +1,144 @@
+using ItemChanger.Locations;
+using ItemChanger.Silksong.Containers;
+using ItemChanger.Silksong.Tags;
+
+namespace ItemChanger.Silksong.RawData;
+
+// Scene + object data sourced from Br3zzly/silksong-completionist (maskShards.ts).
+// ObjectName is "Heart Piece" (or "Heart Piece (1)" for Lava Arena) for all world-pickup entries.
+// "Heart Piece" objects are NOT CollectableItemPickup — they are game-specific interactables.
+// IC replaces them with a new shiny; FloatInPlace prevents the shiny falling off ceiling shards.
+// Quest-reward shards (Gurr, Dark_Hearts, Savage_Beastfly, Sprintmaster) are handled separately.
+// Shop shards (Pebb, Jubilana) are handled via shop locations.
+internal static partial class BaseLocationList
+{
+    public static Location Mask_Shard__Bilewater => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Bilewater,
+        SceneName = "Shadow_13",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Blasted_Steps => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Blasted_Steps,
+        SceneName = "Coral_19b",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Mount Fay: Top of Brightvein
+    public static Location Mask_Shard__Brightvein => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Brightvein,
+        SceneName = "Peak_06",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Cogwork Core: Top of left-most tunnel after arena battle
+    public static Location Mask_Shard__Cogwork_Core => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Cogwork_Core,
+        SceneName = "Song_09",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Deep_Docks => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Deep_Docks,
+        SceneName = "Dock_08",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Far_Fields => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Far_Fields,
+        SceneName = "Bone_East_20",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Far Fields: Top of Skull Cavern lava arena — uses "Heart Piece (1)" object path
+    public static Location Mask_Shard__Lava_Arena => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Lava_Arena,
+        SceneName = "Bone_East_LavaChallenge",
+        ObjectName = "Heart Piece (1)",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Mount_Fay => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Mount_Fay,
+        SceneName = "Peak_04c",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Shellwood => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Shellwood,
+        SceneName = "Shellwood_14",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__The_Slab => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__The_Slab,
+        SceneName = "Slab_17",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Behind a breakable wall in Weavenest Atla
+    public static Location Mask_Shard__Weavenest_Atla => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Weavenest_Atla,
+        SceneName = "Weave_05b",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Whispering_Vaults => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Whispering_Vaults,
+        SceneName = "Library_05",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Wisp_Thicket => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Wisp_Thicket,
+        SceneName = "Wisp_07",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Mask_Shard__Wormways => new ObjectLocation
+    {
+        Name = LocationNames.Mask_Shard__Wormways,
+        SceneName = "Crawl_02",
+        ObjectName = "Heart Piece",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+}

--- a/ItemChanger.Silksong/RawData/BaseLocationList/SpoolFragments.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/SpoolFragments.cs
@@ -1,0 +1,138 @@
+using ItemChanger.Locations;
+using ItemChanger.Silksong.Containers;
+using ItemChanger.Silksong.Tags;
+
+namespace ItemChanger.Silksong.RawData;
+
+// Scene + object data sourced from Br3zzly/silksong-completionist (spoolFragments.ts).
+// ObjectName is "Silk Spool" for all world-pickup entries.
+// "Silk Spool" objects are NOT CollectableItemPickup — FloatInPlace prevents the shiny falling.
+// Shop fragments (Frey, Grindle, Jubilana) are handled via shop locations.
+// Quest fragment (Sherma/"Balm for The Wounded") is handled separately.
+// Flea Caravan fragment is a fleamaster reward — handled separately.
+internal static partial class BaseLocationList
+{
+    // Bone_11b is "Bone Bottom: Above the Bone Bottom settlement"
+    public static Location Spool_Fragment__Mosshome => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Mosshome,
+        SceneName = "Bone_11b",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Bone_East_13 is in the Deep Docks approach from Far Fields
+    public static Location Spool_Fragment__Deep_Docks_East => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Deep_Docks_East,
+        SceneName = "Bone_East_13",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Spool_Fragment__Greymoor => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Greymoor,
+        SceneName = "Greymoor_02",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Peak_01 is The Slab: frosty section towards the left
+    public static Location Spool_Fragment__The_Slab => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__The_Slab,
+        SceneName = "Peak_01",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Spool_Fragment__Weavenest_Atla => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Weavenest_Atla,
+        SceneName = "Weave_11",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Spool_Fragment__Cogwork_Core => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Cogwork_Core,
+        SceneName = "Cog_07",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Library_11b is labeled Underworks (bottom-right hidden area)
+    public static Location Spool_Fragment__Underworks_Spikes => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Underworks_Spikes,
+        SceneName = "Library_11b",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Song_19_entrance is the Grand Gate scene (top of Choral Chambers entrance)
+    public static Location Spool_Fragment__Grand_Gate => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Grand_Gate,
+        SceneName = "Song_19_entrance",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Underworks: behind arena battle
+    public static Location Spool_Fragment__Underworks_Arena => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Underworks_Arena,
+        SceneName = "Under_10",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    // Whiteward: bottom of the elevator shaft
+    public static Location Spool_Fragment__Whiteward => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Whiteward,
+        SceneName = "Ward_01",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Spool_Fragment__Deep_Docks_West => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Deep_Docks_West,
+        SceneName = "Dock_03c",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Spool_Fragment__High_Halls => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__High_Halls,
+        SceneName = "Hang_03_top",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+
+    public static Location Spool_Fragment__Memorium => new ObjectLocation
+    {
+        Name = LocationNames.Spool_Fragment__Memorium,
+        SceneName = "Arborium_09",
+        ObjectName = "Silk Spool",
+        Correction = default,
+        Tags = [FloatShiny]
+    };
+}


### PR DESCRIPTION
Implements all world-pickup Mask Shard (14) and Spool Fragment (13) locations as ObjectLocations, excluding shop and quest-reward items which are handled separately.

Each location uses FloatShiny — a ShinyControlTag combining ShinyType.Instant (contact pickup, same mechanic as mossberry drops) with ShinyFling.FloatInPlace (kinematic rigidbody, no gravity) — so the replacement shiny hovers exactly where the original interactable was without altering pickup difficulty.

ShinyContainer.ModifyContainerInPlace gains ShinyDetachScheduler for FloatInPlace shinies: a DontDestroyOnLoad MonoBehaviour that unparents the shiny from any container hierarchy in LateUpdate. This handles Heart Piece objects parented to breakable containers (e.g. Library_05 jar, Bilewater cocoon) that would otherwise destroy the shiny when broken. Start()-based detach was unreliable because ApplyTargetContext can call SetActive(false), which cancels pending Start() calls.

Closes #110 