### PR TITLE
Implement currency items

### DIFF
--- a/ItemChanger.Silksong/ItemChanger.Silksong.csproj
+++ b/ItemChanger.Silksong/ItemChanger.Silksong.csproj
@@ -97,18 +97,6 @@
     <PackageReference Include="Silksong.Benchwarp" Version="1.1.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>$(SilksongFolder)/BepInEx/plugins/MMHOOK/Managed/MMHOOK_Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="MMHOOK_PlayMaker">
-      <HintPath>$(SilksongFolder)/BepInEx/plugins/MMHOOK/Managed/MMHOOK_PlayMaker.dll</HintPath>
-    </Reference>
-    <Reference Include="MMHOOK_TeamCherry.Localization">
-      <HintPath>$(SilksongFolder)/BepInEx/plugins/MMHOOK/Managed/MMHOOK_TeamCherry.Localization.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <MonoDetourHookGenStripUnusedHooks>true</MonoDetourHookGenStripUnusedHooks>
   </PropertyGroup>
@@ -126,7 +114,7 @@
     </PropertyGroup>
 
     <!-- Local install -->
-    <Copy SourceFiles="@(Binaries)" DestinationFolder="$(SilksongFolder)/BepInEx/plugins/$(ThunderstoreAuthor)-$(AssemblyTitle)/%(Binaries.LocalDir)" Condition="'$(SilksongFolder)' != '' And Exists('$(SilksongFolder)')" />
+    <Copy SourceFiles="@(Binaries)" DestinationFolder="$(SilksongPluginsFolder)/$(ThunderstoreAuthor)-$(AssemblyTitle)/%(Binaries.LocalDir)" Condition="'$(SilksongPluginsFolder)' != '' And Exists('$(SilksongPluginsFolder)')" />
 
     <!-- Thunderstore packaging -->
     <RemoveDir Directories="$(ThunderstoreDir)/temp;$(ThunderstoreDir)/dist" />
@@ -137,7 +125,7 @@
   </Target>
 
 
-  <Target Name="CopyMod" AfterTargets="PostBuildEvent" Condition="'$(SilksongFolder)' != '' And '$(Configuration)' == 'Debug'">
+  <Target Name="CopyMod" AfterTargets="PostBuildEvent" Condition="'$(SilksongPluginsFolder)' != '' And '$(Configuration)' == 'Debug'">
     <ItemGroup>
       <Binaries Include="$(TargetPath)" />
       <Binaries Include="$(TargetDir)/$(TargetName).pdb" />
@@ -146,6 +134,6 @@
       <Binaries Include="Resources/Languages/*.json" LocalDir="languages" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(Binaries)" DestinationFolder="$(SilksongFolder)/BepInEx/plugins/$(ThunderstoreAuthor)-$(TargetName)/%(Binaries.LocalDir)" />
+    <Copy SourceFiles="@(Binaries)" DestinationFolder="$(SilksongPluginsFolder)/$(ThunderstoreAuthor)-$(TargetName)/%(Binaries.LocalDir)" />
   </Target>
 </Project>

--- a/ItemChanger.Silksong/Items/CurrencyItem.cs
+++ b/ItemChanger.Silksong/Items/CurrencyItem.cs
@@ -1,0 +1,82 @@
+﻿using ItemChanger.Enums;
+using ItemChanger.Events.Args;
+using ItemChanger.Items;
+using ItemChanger.Silksong.Containers;
+using ItemChanger.Silksong.Tags;
+using Newtonsoft.Json;
+using UnityEngine;
+
+namespace ItemChanger.Silksong.Items;
+
+public abstract class CurrencyItem : Item
+{
+    public int Amount;
+
+    private bool megaFling = false;
+
+    [JsonIgnore]
+    public abstract CurrencyType CurrencyType { get; }
+
+    protected override void DoLoad()
+    {
+        base.DoLoad();
+        OnGive += CheckMegaFling;
+    }
+
+    protected override void DoUnload()
+    {
+        OnGive -= CheckMegaFling;
+        base.DoUnload();
+    }
+
+    private void CheckMegaFling(ReadOnlyGiveEventArgs args) => megaFling = args.Placement?.HasTag<ChestControlTag>() ?? false;
+
+    public override bool GiveEarly(string containerType) => containerType switch
+    {
+        // TODO: Handle rosary bowls, string caches, other breakables, enemies, etc.
+        ContainerNames.Chest => true,
+        _ => false,
+    };
+
+    // Add currency directly to PlayerData.
+    protected abstract void AddToPlayerData(PlayerData pd);
+
+    // Return the number of each prefab that should spawn when flinging currency into the world.
+    protected abstract IEnumerable<(int, GameObject)> GetPrefabCounts();
+
+    public override void GiveImmediate(GiveInfo info)
+    {
+        if (info.FlingType == FlingType.DirectDeposit || info.Transform == null)
+        {
+            if (HeroController.SilentInstance != null && CurrencyCounterExists())
+                HeroController.SilentInstance!.AddCurrency(Amount, CurrencyType);
+            else
+                AddToPlayerData(PlayerData.instance);
+        }
+        else
+        {
+            bool straightUp = info.FlingType == FlingType.StraightUp;
+            (int angleMin, int angleMax) = straightUp ? (90, 90) : (megaFling ? (65, 115) : (80, 100));
+            (int speedMin, int speedMax) = megaFling ? (30, 45) : (15, 30);
+
+            foreach (var (count, prefab) in GetPrefabCounts())
+            {
+                if (count <= 0) continue;
+                UObject.Destroy(prefab.Spawn()); // Fix spawn bug.
+
+                FlingUtils.SpawnAndFling(new()
+                {
+                    Prefab = prefab,
+                    AmountMin = count,
+                    AmountMax = count,
+                    SpeedMin = speedMin,
+                    SpeedMax = speedMax,
+                    AngleMin = angleMin,
+                    AngleMax = angleMax,
+                }, info.Transform, Vector3.zero);
+            }
+        }   
+    }
+
+    private bool CurrencyCounterExists() => CurrencyCounter._currencyCounters.TryGetValue(CurrencyType, out var counters) && counters.Count > 0;
+}

--- a/ItemChanger.Silksong/Items/RosariesItem.cs
+++ b/ItemChanger.Silksong/Items/RosariesItem.cs
@@ -1,0 +1,48 @@
+﻿using GlobalSettings;
+using ItemChanger.Silksong.Extensions;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChanger.Silksong.Items;
+
+public class RosariesItem : CurrencyItem
+{
+    public static RosariesItem MakeRosariesItem(int amount) => new()
+    {
+        Name = $"{amount}_Rosaries",
+        Amount = amount,
+        UIDef = new UIDefs.MsgUIDef()
+        {
+            Name = ItemChangerLanguageStrings.CreatePayRosariesString(amount.ToValueProvider()),
+            ShopDesc = ItemChangerLanguageStrings.SHOP_DESC_ROSARIES,
+            Sprite = BaseAtlasSprites.Rosaries,
+        },
+    };
+
+    public override CurrencyType CurrencyType => CurrencyType.Money;
+
+    protected override void AddToPlayerData(PlayerData pd) => pd.AddGeo(Amount);
+
+    protected override IEnumerable<(int, GameObject)> GetPrefabCounts()
+    {
+        int remaining = Amount;
+
+        // Make at least 3 small rosaries, plus the remainder for the larger prefabs.
+        int small = Math.Min(3, remaining);
+        small += (remaining - small) % 5;
+        remaining -= small;
+        yield return (small, Gameplay.SmallGeoPrefab);
+
+        // Make at least 3 medium rosaries, plus the remainder for the large prefab.
+        int medium = Math.Min(3, remaining / 5);
+        medium += ((remaining - 5 * medium) % 15) / 5;
+        remaining -= 5 * medium;
+        yield return (medium, Gameplay.MediumGeoPrefab);
+
+        // Make large rosaries (value 15), approx 1/3 of them smooth.
+        int large = remaining / 15;
+        int smooth = 0;
+        for (int i = 0; i < large; i++) if (UnityEngine.Random.Range(0, 3) == 1) ++smooth;
+        yield return (smooth, Gameplay.LargeSmoothGeoPrefab);
+        yield return (large - smooth, Gameplay.LargeGeoPrefab);
+    }
+}

--- a/ItemChanger.Silksong/Items/ShellShardsItem.cs
+++ b/ItemChanger.Silksong/Items/ShellShardsItem.cs
@@ -1,0 +1,43 @@
+﻿using GlobalSettings;
+using ItemChanger.Silksong.Extensions;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChanger.Silksong.Items;
+
+public class ShellShardsItem : CurrencyItem
+{
+    public static ShellShardsItem MakeShellShardsItem(int amount) => new()
+    {
+        Name = $"{amount}_Shell_Shards",
+        Amount = amount,
+        UIDef = new UIDefs.MsgUIDef()
+        {
+            Name = ItemChangerLanguageStrings.CreatePayShellShardsString(amount.ToValueProvider()),
+            ShopDesc = BaseLanguageStrings.Shell_Shards_Desc,
+            Sprite = BaseAtlasSprites.ShellShards,
+        },
+    };
+
+    public override CurrencyType CurrencyType => CurrencyType.Shard;
+
+    protected override void AddToPlayerData(PlayerData pd) => pd.AddShards(Amount);
+
+    protected override IEnumerable<(int, GameObject)> GetPrefabCounts()
+    {
+        int remaining = Amount;
+
+        // Make at least 3 small shards, plus the remainder for the larger prefab.
+        int small = Math.Min(3, remaining);
+        small += (remaining - small) % 5;
+        remaining -= small;
+
+        // Shell shard prefabs are randomized from a pool.
+        var smallPrefabs = Gameplay.Get().shellShardPrefabs;
+        int[] smallCounts = new int[smallPrefabs.Count];
+        for (int i = 0; i < small; i++) smallCounts[UnityEngine.Random.Range(0, smallPrefabs.Count)]++;
+        for (int i = 0; i < smallPrefabs.Count; i++) yield return (smallCounts[i], smallPrefabs[i]);
+
+        // Use mid-size shell shards for the rest.
+        yield return (remaining / 5, Gameplay.ShellShardMidPrefab);
+    }
+}

--- a/ItemChanger.Silksong/RawData/BaseAtlasSprites/Currency.cs
+++ b/ItemChanger.Silksong/RawData/BaseAtlasSprites/Currency.cs
@@ -1,0 +1,17 @@
+﻿using ItemChanger.Silksong.Serialization;
+
+namespace ItemChanger.Silksong.RawData;
+
+internal static partial class BaseAtlasSprites
+{
+    public static AtlasSprite Rosaries => new()
+    {
+        BundleName = "atlases_assets_assets/sprites/_atlases/inventory.spriteatlas",
+        SpriteName = "I_rosary_icon_clean"
+    };
+    public static AtlasSprite ShellShards => new()
+    {
+        BundleName = "atlases_assets_assets/sprites/_atlases/inventory.spriteatlas",
+        SpriteName = "I_shell_shard_icon_large"
+    };
+}

--- a/ItemChanger.Silksong/RawData/BaseLanguageStrings/Materium.cs
+++ b/ItemChanger.Silksong/RawData/BaseLanguageStrings/Materium.cs
@@ -5,4 +5,8 @@ namespace ItemChanger.Silksong.RawData;
 internal static partial class BaseLanguageStrings
 {
     public static LanguageString Rosaries => new("UI", "INV_NAME_COIN");
+
+    public static LanguageString Shell_Shards => new("UI", "INV_NAME_SHARD");
+
+    public static LanguageString Shell_Shards_Desc => new("UI", "INV_DESC_SHARD");
 }

--- a/ItemChanger.Silksong/RawData/ItemChangerLanguageStrings.cs
+++ b/ItemChanger.Silksong/RawData/ItemChangerLanguageStrings.cs
@@ -1,16 +1,13 @@
 ﻿using ItemChanger.Serialization;
 using ItemChanger.Silksong.Extensions;
 using ItemChanger.Silksong.Serialization;
-using ItemChanger.Silksong.Util;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ItemChanger.Silksong.RawData;
 
 internal static class ItemChangerLanguageStrings
 {
     public static LanguageString FMT_PAY_ROSARIES => LanguageString.FromItemChanger(nameof(FMT_PAY_ROSARIES));
+    public static LanguageString FMT_PAY_SHELL_SHARDS => LanguageString.FromItemChanger(nameof(FMT_PAY_SHELL_SHARDS));
     public static LanguageString FMT_FAST_TRAVEL_PATTERN => LanguageString.FromItemChanger(nameof(FMT_FAST_TRAVEL_PATTERN));
     public static LanguageString FMT_MATERIUM_ENTRY_NAME => LanguageString.FromItemChanger(nameof(FMT_MATERIUM_ENTRY_NAME));
     public static LanguageString FMT_JOURNAL_ENTRY_NAME => LanguageString.FromItemChanger(nameof(FMT_JOURNAL_ENTRY_NAME));
@@ -33,12 +30,22 @@ internal static class ItemChangerLanguageStrings
     public static LanguageString INV_NAME_DOWNSLASH => LanguageString.FromItemChanger(nameof(INV_NAME_DOWNSLASH));
     public static LanguageString INV_DESC_ANYSLASH => LanguageString.FromItemChanger(nameof(INV_DESC_ANYSLASH));
 
+    public static LanguageString SHOP_DESC_ROSARIES => LanguageString.FromItemChanger(nameof(SHOP_DESC_ROSARIES));
+
     public static CompositeString CreatePayRosariesString(IValueProvider<int> rosaryCount)
     {
         return CompositeString.Create(FMT_PAY_ROSARIES, new Dictionary<string, IValueProvider<object>>()
         {
             { "ROSARY_COUNT", rosaryCount.Embox() },
             { "ROSARY_NAME", BaseLanguageStrings.Rosaries }
+        });
+    }
+    public static CompositeString CreatePayShellShardsString(IValueProvider<int> shellShardsCount)
+    {
+        return CompositeString.Create(FMT_PAY_SHELL_SHARDS, new Dictionary<string, IValueProvider<object>>()
+        {
+            { "SHELL_SHARDS_COUNT", shellShardsCount.Embox() },
+            { "SHELL_SHARDS_NAME", BaseLanguageStrings.Shell_Shards }
         });
     }
 }

--- a/ItemChanger.Silksong/Resources/Languages/default.json
+++ b/ItemChanger.Silksong/Resources/Languages/default.json
@@ -1,5 +1,6 @@
 {
   "FMT_PAY_ROSARIES": "{ROSARY_COUNT} {ROSARY_NAME}",
+  "FMT_PAY_SHELL_SHARDS": "{SHELL_SHARDS_COUNT} {SHELL_SHARDS_NAME}",
   "FMT_PAY_TOOL_SLOTS": "{0} Tool Slots",
   "FMT_FAST_TRAVEL_PATTERN": "{TRAVEL_TYPE} - {STATION_NAME}",
   "FMT_MATERIUM_ENTRY_NAME": "{0} Entry",
@@ -22,6 +23,8 @@
   "INV_NAME_UPSLASH": "Upslash",
   "INV_NAME_DOWNSLASH": "Downslash",
   "INV_DESC_ANYSLASH": "TODO",
+
+  "SHOP_DESC_ROSARIES": "We're having a firesale today, go ahead and collect your rebate.",
 
   "CREST_HUNTER_NAME": "Crest of Hunter",
   "CREST_HUNTER_V2_NAME": "Crest of Hunter Level 2",

--- a/ItemChangerTesting/ItemChangerTesting.csproj
+++ b/ItemChangerTesting/ItemChangerTesting.csproj
@@ -60,25 +60,25 @@
   <ItemGroup>
     <ProjectReference Include="..\ItemChanger.Silksong\ItemChanger.Silksong.csproj" />
     <Reference Include="Benchwarp">
-      <HintPath>$(SilksongFolder)/BepInEx/plugins/homothety-Benchwarp/Benchwarp.dll</HintPath>
+      <HintPath>$(SilksongPluginsFolder)/homothety-Benchwarp/Benchwarp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>$(SilksongFolder)/BepInEx/plugins/MMHOOK/Managed/MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>$(SilksongPluginsFolder)/MMHOOK/Managed/MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_PlayMaker">
-      <HintPath>$(SilksongFolder)/BepInEx/plugins/MMHOOK/Managed/MMHOOK_PlayMaker.dll</HintPath>
+      <HintPath>$(SilksongPluginsFolder)/MMHOOK/Managed/MMHOOK_PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_TeamCherry.Localization">
-      <HintPath>$(SilksongFolder)/BepInEx/plugins/MMHOOK/Managed/MMHOOK_TeamCherry.Localization.dll</HintPath>
+      <HintPath>$(SilksongPluginsFolder)/MMHOOK/Managed/MMHOOK_TeamCherry.Localization.dll</HintPath>
     </Reference>
   </ItemGroup>
 
-  <Target Name="CopyMod" AfterTargets="PostBuildEvent" Condition="'$(SilksongFolder)' != ''">
+  <Target Name="CopyMod" AfterTargets="PostBuildEvent" Condition="'$(SilksongPluginsFolder)' != ''">
     <ItemGroup>
       <Binaries Include="$(TargetPath)" />
       <Binaries Include="$(TargetDir)/$(TargetName).pdb" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(Binaries)" DestinationFolder="$(SilksongFolder)/BepInEx/plugins/homothety-$(TargetName)" />
+    <Copy SourceFiles="@(Binaries)" DestinationFolder="$(SilksongPluginsFolder)/homothety-$(TargetName)" />
   </Target>
 </Project>

--- a/ItemChangerTesting/ItemTests/CurrencyItemsTest.cs
+++ b/ItemChangerTesting/ItemTests/CurrencyItemsTest.cs
@@ -1,0 +1,51 @@
+﻿using Benchwarp.Data;
+using ItemChanger.Enums;
+using ItemChanger.Locations;
+using ItemChanger.Silksong.Items;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChangerTesting.ItemTests;
+
+internal class CurrencyItemsTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.ItemTests,
+        MenuName = "Currency",
+        MenuDescription = "Tests rosaries and shell shards.",
+        Revision = 2026040900,
+    };
+
+    private void PlaceCurrency(int index, int rosaries, int shellShards, FlingType flingType = FlingType.Everywhere)
+    {
+        var placement = new CoordinateLocation
+        {
+            Name = $"Placement_{index}",
+            SceneName = SceneNames.Tut_02,
+            X = 143 - index * 3,
+            Y = 31.57f,
+            FlingType = flingType,
+            Managed = false,
+        }.Wrap();
+
+        if (rosaries > 0) placement.Add(RosariesItem.MakeRosariesItem(rosaries));
+        if (shellShards > 0) placement.Add(ShellShardsItem.MakeShellShardsItem(shellShards));
+        Profile.AddPlacement(placement);
+    }
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Tut_02, PrimitiveGateNames.right1);
+
+        int index = 0;
+        PlaceCurrency(index++, rosaries: 4, shellShards: 0);
+        PlaceCurrency(index++, rosaries: 0, shellShards: 9);
+        PlaceCurrency(index++, rosaries: 4, shellShards: 0, FlingType.StraightUp);
+        PlaceCurrency(index++, rosaries: 0, shellShards: 9, FlingType.StraightUp);
+        PlaceCurrency(index++, rosaries: 4, shellShards: 0, FlingType.DirectDeposit);
+        PlaceCurrency(index++, rosaries: 0, shellShards: 9, FlingType.DirectDeposit);
+        PlaceCurrency(index++, rosaries: 21, shellShards: 0);
+        PlaceCurrency(index++, rosaries: 0, shellShards: 21);
+        PlaceCurrency(index++, rosaries: 77, shellShards: 22);
+    }
+}


### PR DESCRIPTION
Shell shards don't appear to support 'fling type = straight-up' very well, possibly because they have larger non-circular collider boxes that can clip into the ground on spawn.  Haven't debugged in depth, assuming it's low priority.  Everything else works as expected.