### PR TITLE
Implement Seamstress Location

### DIFF
--- a/ItemChanger.Silksong/Extensions/ICExtensions.cs
+++ b/ItemChanger.Silksong/Extensions/ICExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using ItemChanger.Containers;
 using ItemChanger.Costs;
 using ItemChanger.Items;
+using ItemChanger.Locations;
 using ItemChanger.Placements;
 using ItemChanger.Serialization;
 using ItemChanger.Silksong.RawData;
@@ -18,6 +19,10 @@ internal static class ICExtensions
     /// Converts a struct-returning value provider to an object-returning value provider.
     /// </summary>
     public static IValueProvider<object> Embox<T>(this IValueProvider<T> t) where T : struct => new Box<T> { Source = t };
+    /// <summary>
+    /// Returns a string provider for the items placed at this location.
+    /// </summary>
+    public static IValueProvider<string> UINameProvider(this Location l) => new UIName(l);
     /// <summary>
     /// Returns a name incorporating the name of the placement and the indices of the items associated with the container.
     /// </summary>
@@ -97,15 +102,20 @@ internal static class ICExtensions
         public object Value => Source.Value;
     }
 
-    private class LiftedT<T> : IWritableValueProvider<T>
-    {
-        public required T Value { get; set; }
-    }
-
     private class CastingProvider<TBase, TDerived> : IValueProvider<TDerived> where TDerived : TBase
     {
         public required IValueProvider<TBase> Inner { get; init; }
 
         [JsonIgnore] public TDerived Value => (TDerived)Inner.Value!;
+    }
+
+    private class LiftedT<T> : IWritableValueProvider<T>
+    {
+        public required T Value { get; set; }
+    }
+
+    private class UIName(Location Location) : IValueProvider<string>
+    {
+        public string Value => Location.Placement?.GetUIName() ?? "???";
     }
 }

--- a/ItemChanger.Silksong/Locations/DriftersCloakLocation.cs
+++ b/ItemChanger.Silksong/Locations/DriftersCloakLocation.cs
@@ -1,0 +1,68 @@
+﻿using Benchwarp.Data;
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
+using ItemChanger.Locations;
+using ItemChanger.Silksong.Containers;
+using ItemChanger.Silksong.RawData;
+using Silksong.FsmUtil;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ItemChanger.Silksong.Locations;
+
+public class DriftersCloakLocation : AutoLocation
+{
+    [SetsRequiredMembers]
+    public DriftersCloakLocation()
+    {
+        SceneName = SceneNames.Bone_East_Umbrella;
+        Name = LocationNames.Drifter_s_Cloak;
+    }
+
+    protected override void DoLoad()
+    {
+        this.InjectPreviewText(new("Quests", "QUEST_BROLLY_GET_DESC"), ItemChangerLanguageStrings.QUEST_BROLLY_GET_DESC_PREVIEW);
+        this.InjectPreviewText(new("Wilds", "SEAMSTRESS_BROLLY_QUEST_OFFER"), ItemChangerLanguageStrings.SEAMSTRESS_BROLLY_QUEST_OFFER_PREVIEW);
+        this.InjectPreviewText(new("Wilds", "SEAMSTRESS_BROLLY_QUEST_REOFFER"), ItemChangerLanguageStrings.SEAMSTRESS_BROLLY_QUEST_REOFFER_PREVIEW);
+        Using(new FsmEditGroup() {{ new(SceneName!, "Seamstress", "Dialogue"), ModifyFsm }});
+    }
+
+    protected override void DoUnload() { }
+
+    private void ModifyFsm(PlayMakerFSM fsm)
+    {
+        fsm.MustGetState("Offer Quest").InsertMethod(0, _ => Placement?.AddVisitFlag(Enums.VisitState.Previewed));
+        fsm.MustGetState("Reoffer Quest").InsertMethod(0, _ => Placement?.AddVisitFlag(Enums.VisitState.Previewed));
+
+        // Note: It's possible for the player to brick their save if they somehow trigger a save after completing the quest but before receiving the reward.
+        // This should not generally be possible without debug tools.
+        var giveState = fsm.MustGetState("Msg");
+        giveState.GetFirstActionOfType<CreateUIMsgGetItem>()!.enabled = false;
+        giveState.GetFirstActionOfType<SetFsmString>()!.enabled = false;
+        giveState.GetFirstActionOfType<SetPlayerDataVariable>()!.enabled = false;
+        giveState.AddMethod(_ =>
+        {
+            var obj = GameObject.Find("_NPCs/Seamstress");
+            Placement?.GiveAll(new()
+            {
+                FlingType = Enums.FlingType.Everywhere,
+                MessageType = Enums.MessageType.SmallPopup | Enums.MessageType.LargePopup,
+                Transform = obj != null ? obj.transform : null,
+            },
+            callback: () => fsm.SendEvent("GET ITEM MSG END"));
+        });
+
+        // Skip the cloak anim unless it's a dearest.
+        bool Dearest() => Placement?.Items.Any(i => i.Name == ItemNames.Drifter_s_Cloak) ?? false;
+
+        var skipEvent = FsmEvent.GetFsmEvent("SKIP");
+        var fadeUpState = fsm.MustGetState("Fade Up");
+        fadeUpState.AddTransition("SKIP", "To Idle");
+        fadeUpState.InsertMethod(0, _ =>
+        {
+            if (Dearest()) return;
+            
+            fadeUpState.GetFirstActionOfType<Tk2dPlayAnimationWithEvents>()?.enabled = false;
+            fadeUpState.GetFirstActionOfType<Wait>()?.finishEvent = skipEvent;
+        });
+    }
+}

--- a/ItemChanger.Silksong/RawData/BaseLocationList/SkillsAbilitiesCrests.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/SkillsAbilitiesCrests.cs
@@ -1,6 +1,7 @@
 using ItemChanger.Locations;
 using ItemChanger.Silksong.Locations;
 using Benchwarp.Data;
+using ItemChanger.Silksong.Serialization;
 
 namespace ItemChanger.Silksong.RawData;
 
@@ -40,6 +41,23 @@ internal static partial class BaseLocationList
     {
         SceneName = SceneNames.Belltown_Room_doctor,
         Name = LocationNames.Crest_of_Witch,
+    };
+
+    public static Location Drifter_s_Cloak => new DualLocation
+    {
+        SceneName = SceneNames.Bone_East_Umbrella,
+        Name = LocationNames.Drifter_s_Cloak,
+        Test = new QuestCompletionBool(Quests.Brolly_Get),
+        FalseLocation = new DriftersCloakLocation(),
+        TrueLocation = new CoordinateLocation()
+        {
+            SceneName = SceneNames.Bone_East_Umbrella,
+            Name = LocationNames.Drifter_s_Cloak,
+            X = 23.75f,
+            Y = 8f,
+            FlingType = Enums.FlingType.Everywhere,
+            Managed = false,
+        },
     };
 
     public static Location Eva => new EvaLocation

--- a/ItemChanger.Silksong/RawData/ItemChangerLanguageStrings.cs
+++ b/ItemChanger.Silksong/RawData/ItemChangerLanguageStrings.cs
@@ -1,6 +1,8 @@
-﻿using ItemChanger.Serialization;
+﻿using ItemChanger.Locations;
+using ItemChanger.Serialization;
 using ItemChanger.Silksong.Extensions;
 using ItemChanger.Silksong.Serialization;
+using TeamCherry.Localization;
 
 namespace ItemChanger.Silksong.RawData;
 
@@ -45,6 +47,7 @@ internal static class ItemChangerLanguageStrings
             { "ROSARY_NAME", BaseLanguageStrings.Rosaries }
         });
     }
+
     public static CompositeString CreatePayShellShardsString(IValueProvider<int> shellShardsCount)
     {
         return CompositeString.Create(FMT_PAY_SHELL_SHARDS, new Dictionary<string, IValueProvider<object>>()
@@ -52,5 +55,16 @@ internal static class ItemChangerLanguageStrings
             { "SHELL_SHARDS_COUNT", shellShardsCount.Embox() },
             { "SHELL_SHARDS_NAME", BaseLanguageStrings.Shell_Shards }
         });
+    }
+
+    public static void InjectPreviewText(this Location self, LocalisedString id, LanguageString itemChangerTemplate)
+    {
+        LanguageEditGroup group = [];
+        var replacement = CompositeString.Create(itemChangerTemplate, new Dictionary<string, IValueProvider<object>>()
+        {
+            { "PREVIEW_TEXT", self.UINameProvider() },
+        });
+        group.Add(new(Sheet: id.Sheet, Key: id.Key), orig => replacement.Value);
+        self.Using(group);
     }
 }

--- a/ItemChanger.Silksong/RawData/ItemChangerLanguageStrings.cs
+++ b/ItemChanger.Silksong/RawData/ItemChangerLanguageStrings.cs
@@ -1,6 +1,8 @@
-﻿using ItemChanger.Serialization;
+﻿using ItemChanger.Locations;
+using ItemChanger.Serialization;
 using ItemChanger.Silksong.Extensions;
 using ItemChanger.Silksong.Serialization;
+using TeamCherry.Localization;
 
 namespace ItemChanger.Silksong.RawData;
 
@@ -35,6 +37,9 @@ internal static class ItemChangerLanguageStrings
     public static LanguageString INV_DESC_TAUNT => LanguageString.FromItemChanger(nameof(INV_DESC_TAUNT));
     public static LanguageString GET_TAUNT_1 => LanguageString.FromItemChanger(nameof(GET_TAUNT_1));
 
+    public static LanguageString QUEST_BROLLY_GET_DESC_PREVIEW => LanguageString.FromItemChanger(nameof(QUEST_BROLLY_GET_DESC_PREVIEW));
+    public static LanguageString SEAMSTRESS_BROLLY_QUEST_OFFER_PREVIEW => LanguageString.FromItemChanger(nameof(SEAMSTRESS_BROLLY_QUEST_OFFER_PREVIEW));
+    public static LanguageString SEAMSTRESS_BROLLY_QUEST_REOFFER_PREVIEW => LanguageString.FromItemChanger(nameof(SEAMSTRESS_BROLLY_QUEST_REOFFER_PREVIEW));
     public static LanguageString SHOP_DESC_ROSARIES => LanguageString.FromItemChanger(nameof(SHOP_DESC_ROSARIES));
 
     public static CompositeString CreatePayRosariesString(IValueProvider<int> rosaryCount)
@@ -45,6 +50,7 @@ internal static class ItemChangerLanguageStrings
             { "ROSARY_NAME", BaseLanguageStrings.Rosaries }
         });
     }
+
     public static CompositeString CreatePayShellShardsString(IValueProvider<int> shellShardsCount)
     {
         return CompositeString.Create(FMT_PAY_SHELL_SHARDS, new Dictionary<string, IValueProvider<object>>()
@@ -52,5 +58,16 @@ internal static class ItemChangerLanguageStrings
             { "SHELL_SHARDS_COUNT", shellShardsCount.Embox() },
             { "SHELL_SHARDS_NAME", BaseLanguageStrings.Shell_Shards }
         });
+    }
+
+    public static void InjectPreviewText(this Location self, LocalisedString id, LanguageString itemChangerTemplate)
+    {
+        LanguageEditGroup group = [];
+        var replacement = CompositeString.Create(itemChangerTemplate, new Dictionary<string, IValueProvider<object>>()
+        {
+            { "PREVIEW_TEXT", self.UINameProvider() },
+        });
+        group.Add(new(Sheet: id.Sheet, Key: id.Key), orig => replacement.Value);
+        self.Using(group);
     }
 }

--- a/ItemChanger.Silksong/Resources/Languages/default.json
+++ b/ItemChanger.Silksong/Resources/Languages/default.json
@@ -43,5 +43,9 @@
 
   "FREE": "Free",
   "OBTAINED": "Obtained",
-  "PAID": "Paid"
+  "PAID": "Paid",
+
+  "QUEST_BROLLY_GET_DESC_PREVIEW": "Hunt Hokers in the Far Fields and collect Spine Cores for {PREVIEW_TEXT}.",
+  "SEAMSTRESS_BROLLY_QUEST_OFFER_PREVIEW": "If you’re planning to ascend from these low fields, you’ll be needing {PREVIEW_TEXT}, and I’m just the bug to help.<page>Head for the caves beyond my home. The bugs within produce a spine with a marvellous core, flexible yet strong.<page>Cut their spines and collect the cores. Return to me, and I’ll soon have your old cloak transformed into {PREVIEW_TEXT}.",
+  "SEAMSTRESS_BROLLY_QUEST_REOFFER_PREVIEW": "Ready to reconsider my offer? Good for you! You won’t be going far without {PREVIEW_TEXT}, dear."
 }

--- a/ItemChanger.Silksong/Serialization/QuestCompletionBool.cs
+++ b/ItemChanger.Silksong/Serialization/QuestCompletionBool.cs
@@ -1,0 +1,10 @@
+﻿using ItemChanger.Serialization;
+using Newtonsoft.Json;
+
+namespace ItemChanger.Silksong.Serialization;
+
+public record QuestCompletionBool(string QuestName) : IValueProvider<bool>
+{
+    [JsonIgnore]
+    public bool Value => QuestManager.TryGetFullQuestBase(QuestName, out var quest) && quest.Completion.IsCompleted;
+}

--- a/ItemChanger.Silksong/StartDefs/BenchwarpStartDef.cs
+++ b/ItemChanger.Silksong/StartDefs/BenchwarpStartDef.cs
@@ -1,0 +1,8 @@
+﻿using Benchwarp.Benches;
+
+namespace ItemChanger.Silksong.StartDefs;
+
+public class BenchwarpStartDef(BenchData BenchData): StartDef
+{
+    public override RespawnInfo GetRespawnInfo() => BenchData.RespawnInfo.GetRespawnInfo();
+}

--- a/ItemChangerTesting/ItemChangerTestingPlugin.cs
+++ b/ItemChangerTesting/ItemChangerTestingPlugin.cs
@@ -1,8 +1,8 @@
 ﻿using BepInEx;
 using BepInEx.Configuration;
+using ItemChanger;
 using ItemChanger.Events;
 using ItemChanger.Silksong;
-using ItemChanger.Silksong.Assets;
 using Silksong.ModMenu.Elements;
 using Silksong.ModMenu.Models;
 using Silksong.ModMenu.Plugin;
@@ -10,7 +10,7 @@ using Silksong.ModMenu.Screens;
 
 namespace ItemChangerTesting
 {
-    [BepInDependency(ItemChanger.Silksong.ItemChangerPlugin.Id)]
+    [BepInDependency(ItemChangerPlugin.Id)]
     [BepInAutoPlugin(id: "io.github.testing.silksong.itemchanger")]
     public partial class ItemChangerTestingPlugin : BaseUnityPlugin, IModMenuCustomMenu
     {
@@ -46,10 +46,15 @@ namespace ItemChangerTesting
 
             TextButton run = new("Erase save slot and launch test.");
             run.OnSubmit += Run;
+
+            TextButton testMethods = new("Test Methods");
+            testMethods.OnSubmit += ShowTestMethods;
+
             screen.Add(saveSlotSelector!);
             screen.Add(testFolderSelector!);
             screen.Add(testSelector!);
             screen.Add(run);
+            screen.Add(testMethods);
 
             void UpdateFolder(object sender, EventArgs args) => model.UpdateValues([.. Test.TestGroups[cfgTestFolder.Value]], 0);
             cfgTestFolder.SettingChanged += UpdateFolder;
@@ -71,6 +76,51 @@ namespace ItemChangerTesting
             }
         }
 
+        private Test? lastLoadedTest;
+        private AbstractMenuScreen? testMethodsScreen;
+
+        void ShowTestMethods()
+        {
+            var activeTest = ItemChangerHost.Singleton.ActiveProfile?.Modules.Get<Test>();
+            if (activeTest == null)
+            {
+                Logger.LogError("No active Test module.");
+                return;
+            }
+
+            if (lastLoadedTest == activeTest)
+            {
+                MenuScreenNavigation.Show(testMethodsScreen!);
+                return;
+            }
+
+            List<(string, Action)> hooks = [.. activeTest.TestMethods()];
+            if (hooks.Count == 0)
+            {
+                Logger.LogError($"Test '{activeTest.GetMetadata().MenuName}' has no test methods.");
+                return;
+            }
+
+            PaginatedMenuScreenBuilder builder = new($"{activeTest.GetMetadata().MenuName} Test Methods");
+            foreach (var (name, hook) in hooks)
+            {
+                TextButton button = new(name);
+                button.OnSubmit += hook;
+                builder.Add(button);
+            }
+
+            testMethodsScreen?.Dispose();
+            testMethodsScreen = builder.Build();
+            testMethodsScreen.OnDispose += () =>
+            {
+                testMethodsScreen = null;
+                lastLoadedTest = null;
+            };
+
+            lastLoadedTest = activeTest;
+            MenuScreenNavigation.Show(testMethodsScreen);
+        }
+
         // TODO - this probably ought to be in ItemChanger.Core
         private void LogLifecycleEvents()
         {
@@ -85,6 +135,6 @@ namespace ItemChangerTesting
             SilksongHost.Instance.LifecycleEvents.AfterContinueGame += () => Logger.LogInfo("Invoked " + nameof(LifecycleEvents.AfterContinueGame));
         }
 
-        public string ModMenuName() => "ItemChangerTesting";
+        public LocalizedText ModMenuName() => "ItemChangerTesting";
     }
 }

--- a/ItemChangerTesting/ItemChangerTestingPlugin.cs
+++ b/ItemChangerTesting/ItemChangerTestingPlugin.cs
@@ -4,6 +4,7 @@ using ItemChanger.Events;
 using ItemChanger.Silksong;
 using ItemChanger.Silksong.Assets;
 using Silksong.ModMenu.Elements;
+using Silksong.ModMenu.Models;
 using Silksong.ModMenu.Plugin;
 using Silksong.ModMenu.Screens;
 
@@ -39,8 +40,8 @@ namespace ItemChangerTesting
             MenuElementGenerators.CreateIntSliderGenerator()(cfgSaveSlot, out MenuElement? saveSlotSelector);
             ConfigEntryFactory.GenerateEnumChoiceElement(cfgTestFolder, out MenuElement? testFolderSelector);
 
-            DynamicChoiceModel model = new();
-            cfgTestFolder.SettingChanged += model.UpdateFolder;
+            ListChoiceModel<Test> model = new([.. Test.TestGroups[cfgTestFolder.Value]]);
+            model.DisplayFn = (_, t) => t.GetMetadata().MenuName;
             DynamicDescriptionChoiceElement<Test> testSelector = new("Test", model, "The test to launch.", t => t.GetMetadata().MenuDescription);
 
             TextButton run = new("Erase save slot and launch test.");
@@ -50,7 +51,9 @@ namespace ItemChangerTesting
             screen.Add(testSelector!);
             screen.Add(run);
 
-            screen.OnDispose += () => cfgTestFolder.SettingChanged -= model.UpdateFolder;
+            void UpdateFolder(object sender, EventArgs args) => model.UpdateValues([.. Test.TestGroups[cfgTestFolder.Value]], 0);
+            cfgTestFolder.SettingChanged += UpdateFolder;
+            screen.OnDispose += () => cfgTestFolder.SettingChanged -= UpdateFolder;
 
             return screen;
 

--- a/ItemChangerTesting/LocationTests/DriftersCloakLocationTest.cs
+++ b/ItemChangerTesting/LocationTests/DriftersCloakLocationTest.cs
@@ -1,0 +1,27 @@
+﻿using ItemChanger.Silksong.RawData;
+
+namespace ItemChangerTesting.LocationTests;
+
+internal class DriftersCloakLocationTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.LocationTests,
+        MenuName = "Drifter's Cloak Location",
+        MenuDescription = "Tests giving items from the Seamstress in Far Fields.",
+        Revision = 2026031400,
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartAt(Benchwarp.Data.BaseBenchList.Seamstress);
+        Profile.AddPlacement(Finder.GetLocation(LocationNames.Drifter_s_Cloak)!.Wrap().Add(
+            Finder.GetItem(ItemNames.Surgeon_s_Key)!));
+    }
+
+    public override IEnumerable<(string, Action)> TestMethods()
+    {
+        yield return ("Collect Spines", () => QuestUtil.SetReadyToComplete(Quests.Brolly_Get));
+        yield return ("Mark Completed", () => QuestUtil.SetCompleted(Quests.Brolly_Get));
+    }
+}

--- a/ItemChangerTesting/Test.cs
+++ b/ItemChangerTesting/Test.cs
@@ -38,6 +38,8 @@ namespace ItemChangerTesting
             });
         }
 
+        protected static void StartAt(Benchwarp.Benches.BenchData benchData) => StartAt(new BenchwarpStartDef(benchData));
+
         protected internal static void StartAt(StartDef start)
         {
             ModuleCollection mods = ItemChangerHost.Singleton.ActiveProfile!.Modules;

--- a/ItemChangerTesting/Test.cs
+++ b/ItemChangerTesting/Test.cs
@@ -38,6 +38,8 @@ namespace ItemChangerTesting
             });
         }
 
+        protected static void StartAt(Benchwarp.Benches.BenchData benchData) => StartAt(new BenchwarpStartDef(benchData));
+
         protected static void StartAt(StartDef start)
         {
             ModuleCollection mods = ItemChangerHost.Singleton.ActiveProfile!.Modules;

--- a/ItemChangerTesting/Test.cs
+++ b/ItemChangerTesting/Test.cs
@@ -63,5 +63,8 @@ namespace ItemChangerTesting
         }
 
         protected virtual void OnEnterGame() { }
+
+        // Arbitrary named hooks associated with the test, to simulate quest completion, etc.
+        public virtual IEnumerable<(string, Action)> TestMethods() => [];
     }
 }


### PR DESCRIPTION
Depends on https://github.com/homothetyhk/ItemChanger.Silksong/pull/164 and https://github.com/homothetyhk/ItemChanger.Silksong/pull/165.

In addition to implementing the "Drifter's Cloak Location", this PR also adds some building blocks for future locations.
 - A basic helper for injecting previews into dialogue
 - Test helpers for setting a Bench as a starting point
 - A new QuestCompletionBool for DualLocations
   - It is feasible, though improbable, that a player marks the brolly quest completed, triggers a save, and then crashes the game before receiving the item.  This would brick a vanilla save file because the completion and item grant do not happen on the same frame, and the dialogue option to receive the reward is closed once the quest is completed.  It is probably good practice to use DualLocations in general for a variety of reasons, for instance for some future 'QuestSync' ItemSync add-on.