### PR TITLE
Implement fast travel CoordinateLocations (issue #186)

### DIFF
--- a/ItemChanger.Silksong/RawData/BaseItemList/FastTravel.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/FastTravel.cs
@@ -12,17 +12,17 @@ internal static partial class BaseItemList
 {
     // TODO - add shop descs
 
-    private static UIDef GetBellwayUIDef(LanguageString station)
+    private static UIDef GetBellwayUIDef(LanguageString station, bool format = true)
     {
         return new MsgUIDef()
         {
-            Name = CompositeString.Create(
+            Name = format ? CompositeString.Create(
                 LanguageString.FromItemChanger("FMT_FAST_TRAVEL_PATTERN"),
                 new Dictionary<string, IValueProvider<object>>
                 {
                     { "TRAVEL_TYPE", BaseLanguageStrings.Bellway },
                     { "STATION_NAME", station }
-                }),
+                }) : station,
             ShopDesc = null!,
             Sprite = BaseAtlasSprites.Bellway, 
         };
@@ -37,7 +37,7 @@ internal static partial class BaseItemList
                 new Dictionary<string, IValueProvider<object>>
                 {
                     { "TRAVEL_TYPE", BaseLanguageStrings.Ventrica },
-                    { "STATION_TYPE", station } 
+                    { "STATION_NAME", station } 
                 }),
             ShopDesc = null!,
             Sprite = BaseAtlasSprites.Ventrica,
@@ -91,7 +91,7 @@ internal static partial class BaseItemList
     {
         Name = ItemNames.Bellway__Grand_Bellway,
         BoolName = nameof(PlayerData.UnlockedCityStation),
-        UIDef = GetBellwayUIDef(BaseLanguageStrings.Fast_Travel__STATION_NAME_CITADEL),
+        UIDef = GetBellwayUIDef(BaseLanguageStrings.Fast_Travel__STATION_NAME_CITADEL, format: false),
     };
     public static Item Bellway__The_Slab => new PDBoolItem
     {

--- a/ItemChanger.Silksong/RawData/BaseLanguageStrings/FastTravel.cs
+++ b/ItemChanger.Silksong/RawData/BaseLanguageStrings/FastTravel.cs
@@ -7,7 +7,7 @@ internal static partial class BaseLanguageStrings
     public static LanguageString Bellway => new("UI", "KEY_BELLWAY");
     public static LanguageString Ventrica => new("UI", "KEY_TUBE");
 
-    public static LanguageString Fast_Travel__STATION_NAME_BONETOWN => new("Fast Travel", "STATION_NAME_BONETOwN");
+    public static LanguageString Fast_Travel__STATION_NAME_BONETOWN => new("Fast Travel", "STATION_NAME_BONETOWN");
     public static LanguageString Fast_Travel__STATION_NAME_BONE => new("Fast Travel", "STATION_NAME_BONE");
     public static LanguageString Fast_Travel__STATION_NAME_DOCKS => new("Fast Travel", "STATION_NAME_DOCKS");
     public static LanguageString Fast_Travel__STATION_NAME_BONEFOREST_EAST => new("Fast Travel", "STATION_NAME_BONEFOREST_EAST");

--- a/ItemChanger.Silksong/RawData/BaseLocationList/FastTravel.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/FastTravel.cs
@@ -7,6 +7,10 @@ namespace ItemChanger.Silksong.RawData;
 
 internal static partial class BaseLocationList
 {
+    // Coordinates were captured by standing Hornet at the desired check position;
+    // they reflect Hornet's transform position so containers (chests, etc.) place
+    // sensibly when this location is replaced.
+
     // === Bellway locations ===
 
     // Free — unlocked after Bell Beast
@@ -14,8 +18,8 @@ internal static partial class BaseLocationList
     {
         Name = LocationNames.Bellway__Bone_Bottom,
         SceneName = SceneNames.Bellway_01,
-        X = 52.37f,
-        Y = 21.59f,
+        X = 69.90f,
+        Y = 9.60f,
         Managed = false,
     };
 
@@ -24,88 +28,88 @@ internal static partial class BaseLocationList
     {
         Name = LocationNames.Bellway__The_Marrow,
         SceneName = SceneNames.Bone_05,
-        X = 137.18f,
-        Y = 4.57f,
+        X = 108.62f,
+        Y = 6.57f,
         Managed = false,
     };
 
-    // 40 rosaries — near Toll Machine at (83.71, 16.15)
+    // 40 rosaries
     public static Location Bellway__Deep_Docks => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Deep_Docks,
         SceneName = SceneNames.Bellway_02,
-        X = 86f,
-        Y = 16f,
+        X = 86.75f,
+        Y = 17.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(40) });
 
-    // 40 rosaries — near Toll Machine at (69.34, 8.15)
+    // 40 rosaries
     public static Location Bellway__Far_Fields => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Far_Fields,
         SceneName = SceneNames.Bellway_03,
-        X = 71f,
-        Y = 8f,
+        X = 67.14f,
+        Y = 9.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(40) });
 
-    // 60 rosaries — near Toll Machine at (69.46, 8.13)
+    // 60 rosaries
     public static Location Bellway__Greymoor => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Greymoor,
         SceneName = SceneNames.Bellway_04,
-        X = 71f,
-        Y = 8f,
+        X = 66.83f,
+        Y = 9.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(60) });
 
-    // 60 rosaries — near Toll Machine at (28.28, 95.24)
+    // 60 rosaries
     public static Location Bellway__Bellhart => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Bellhart,
         SceneName = SceneNames.Belltown_basement,
-        X = 30f,
-        Y = 95f,
+        X = 31.74f,
+        Y = 96.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(60) });
 
-    // 40 rosaries — near Toll Machine at (57.94, 5.14)
+    // 40 rosaries
     public static Location Bellway__Shellwood => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Shellwood,
         SceneName = SceneNames.Shellwood_19,
-        X = 60f,
-        Y = 5f,
+        X = 54.91f,
+        Y = 6.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(40) });
 
-    // 60 rosaries — near Toll Machine at (94.32, 12.23)
+    // 60 rosaries
     public static Location Bellway__Blasted_Steps => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Blasted_Steps,
         SceneName = SceneNames.Bellway_08,
-        X = 96f,
-        Y = 12f,
+        X = 97.81f,
+        Y = 13.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(60) });
 
-    // 40 rosaries — near Toll Machine at (44.53, 5.35)
+    // 40 rosaries
     public static Location Bellway__The_Slab => new CoordinateLocation
     {
         Name = LocationNames.Bellway__The_Slab,
         SceneName = SceneNames.Slab_06,
-        X = 46f,
-        Y = 5f,
+        X = 47.95f,
+        Y = 6.72f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(40) });
 
-    // 80 rosaries — near Bellway Toll Machine at (39.87, 10.18)
+    // 80 rosaries
     public static Location Bellway__Grand_Bellway => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Grand_Bellway,
         SceneName = SceneNames.Bellway_City,
-        X = 42f,
-        Y = 10f,
+        X = 36.49f,
+        Y = 11.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
@@ -114,18 +118,18 @@ internal static partial class BaseLocationList
     {
         Name = LocationNames.Bellway__Bilewater,
         SceneName = SceneNames.Bellway_Shadow,
-        X = 44.11f,
+        X = 47.90f,
         Y = 22.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
-    // 80 rosaries — near Toll Machine at (51.49, 21.13)
+    // 80 rosaries
     public static Location Bellway__Putrified_Ducts => new CoordinateLocation
     {
         Name = LocationNames.Bellway__Putrified_Ducts,
         SceneName = SceneNames.Bellway_Aqueduct,
-        X = 53f,
-        Y = 21f,
+        X = 48.56f,
+        Y = 22.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
@@ -136,18 +140,18 @@ internal static partial class BaseLocationList
     {
         Name = LocationNames.Ventrica__Terminus,
         SceneName = SceneNames.Tube_Hub,
-        X = 68.77f,
+        X = 71.91f,
         Y = 39.57f,
         Managed = false,
     };
 
-    // 80 rosaries — near tube entrance at (16.08, 6.24)
+    // 80 rosaries
     public static Location Ventrica__Memorium => new CoordinateLocation
     {
         Name = LocationNames.Ventrica__Memorium,
         SceneName = SceneNames.Arborium_Tube,
-        X = 18f,
-        Y = 6f,
+        X = 20.10f,
+        Y = 6.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
@@ -156,48 +160,48 @@ internal static partial class BaseLocationList
     {
         Name = LocationNames.Ventrica__High_Halls,
         SceneName = SceneNames.Hang_06b,
-        X = 23.14f,
+        X = 28.43f,
         Y = 4.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
-    // 80 rosaries — near tube entrance at (16.08, 6.24)
+    // 80 rosaries
     public static Location Ventrica__First_Shrine => new CoordinateLocation
     {
         Name = LocationNames.Ventrica__First_Shrine,
         SceneName = SceneNames.Song_Enclave_Tube,
-        X = 18f,
-        Y = 6f,
+        X = 19.27f,
+        Y = 6.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
-    // 80 rosaries — near tube entrance at (48.01, 4.24)
+    // 80 rosaries
     public static Location Ventrica__Choral_Chambers => new CoordinateLocation
     {
         Name = LocationNames.Ventrica__Choral_Chambers,
         SceneName = SceneNames.Song_01b,
-        X = 50f,
-        Y = 4f,
+        X = 44.28f,
+        Y = 4.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
-    // 80 rosaries — near tube entrance at (81.66, 11.28)
+    // 80 rosaries
     public static Location Ventrica__Grand_Bellway => new CoordinateLocation
     {
         Name = LocationNames.Ventrica__Grand_Bellway,
         SceneName = SceneNames.Bellway_City,
-        X = 83f,
-        Y = 11f,
+        X = 76.61f,
+        Y = 11.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 
-    // 80 rosaries — near tube entrance at (66.21, 4.25)
+    // 80 rosaries
     public static Location Ventrica__Underworks => new CoordinateLocation
     {
         Name = LocationNames.Ventrica__Underworks,
         SceneName = SceneNames.Under_22,
-        X = 68f,
-        Y = 4f,
+        X = 69.74f,
+        Y = 4.57f,
         Managed = false,
     }.WithTag(new CostTag { Cost = new RosaryCost(80) });
 }

--- a/ItemChanger.Silksong/RawData/BaseLocationList/FastTravel.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/FastTravel.cs
@@ -1,0 +1,203 @@
+using Benchwarp.Data;
+using ItemChanger.Locations;
+using ItemChanger.Silksong.Costs;
+using ItemChanger.Tags;
+
+namespace ItemChanger.Silksong.RawData;
+
+internal static partial class BaseLocationList
+{
+    // === Bellway locations ===
+
+    // Free — unlocked after Bell Beast
+    public static Location Bellway__Bone_Bottom => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Bone_Bottom,
+        SceneName = SceneNames.Bellway_01,
+        X = 52.37f,
+        Y = 21.59f,
+        Managed = false,
+    };
+
+    // Free — unlocked after Bell Beast
+    public static Location Bellway__The_Marrow => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__The_Marrow,
+        SceneName = SceneNames.Bone_05,
+        X = 137.18f,
+        Y = 4.57f,
+        Managed = false,
+    };
+
+    // 40 rosaries — near Toll Machine at (83.71, 16.15)
+    public static Location Bellway__Deep_Docks => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Deep_Docks,
+        SceneName = SceneNames.Bellway_02,
+        X = 86f,
+        Y = 16f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+
+    // 40 rosaries — near Toll Machine at (69.34, 8.15)
+    public static Location Bellway__Far_Fields => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Far_Fields,
+        SceneName = SceneNames.Bellway_03,
+        X = 71f,
+        Y = 8f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+
+    // 60 rosaries — near Toll Machine at (69.46, 8.13)
+    public static Location Bellway__Greymoor => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Greymoor,
+        SceneName = SceneNames.Bellway_04,
+        X = 71f,
+        Y = 8f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(60) });
+
+    // 60 rosaries — near Toll Machine at (28.28, 95.24)
+    public static Location Bellway__Bellhart => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Bellhart,
+        SceneName = SceneNames.Belltown_basement,
+        X = 30f,
+        Y = 95f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(60) });
+
+    // 40 rosaries — near Toll Machine at (57.94, 5.14)
+    public static Location Bellway__Shellwood => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Shellwood,
+        SceneName = SceneNames.Shellwood_19,
+        X = 60f,
+        Y = 5f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+
+    // 60 rosaries — near Toll Machine at (94.32, 12.23)
+    public static Location Bellway__Blasted_Steps => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Blasted_Steps,
+        SceneName = SceneNames.Bellway_08,
+        X = 96f,
+        Y = 12f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(60) });
+
+    // 40 rosaries — near Toll Machine at (44.53, 5.35)
+    public static Location Bellway__The_Slab => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__The_Slab,
+        SceneName = SceneNames.Slab_06,
+        X = 46f,
+        Y = 5f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+
+    // 80 rosaries — near Bellway Toll Machine at (39.87, 10.18)
+    public static Location Bellway__Grand_Bellway => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Grand_Bellway,
+        SceneName = SceneNames.Bellway_City,
+        X = 42f,
+        Y = 10f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // 80 rosaries
+    public static Location Bellway__Bilewater => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Bilewater,
+        SceneName = SceneNames.Bellway_Shadow,
+        X = 44.11f,
+        Y = 22.57f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // 80 rosaries — near Toll Machine at (51.49, 21.13)
+    public static Location Bellway__Putrified_Ducts => new CoordinateLocation
+    {
+        Name = LocationNames.Bellway__Putrified_Ducts,
+        SceneName = SceneNames.Bellway_Aqueduct,
+        X = 53f,
+        Y = 21f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // === Ventrica locations ===
+
+    // Free — locked from outside, unlocks when other stations accessed
+    public static Location Ventrica__Terminus => new CoordinateLocation
+    {
+        Name = LocationNames.Ventrica__Terminus,
+        SceneName = SceneNames.Tube_Hub,
+        X = 68.77f,
+        Y = 39.57f,
+        Managed = false,
+    };
+
+    // 80 rosaries — near tube entrance at (16.08, 6.24)
+    public static Location Ventrica__Memorium => new CoordinateLocation
+    {
+        Name = LocationNames.Ventrica__Memorium,
+        SceneName = SceneNames.Arborium_Tube,
+        X = 18f,
+        Y = 6f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // 80 rosaries
+    public static Location Ventrica__High_Halls => new CoordinateLocation
+    {
+        Name = LocationNames.Ventrica__High_Halls,
+        SceneName = SceneNames.Hang_06b,
+        X = 23.14f,
+        Y = 4.57f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // 80 rosaries — near tube entrance at (16.08, 6.24)
+    public static Location Ventrica__First_Shrine => new CoordinateLocation
+    {
+        Name = LocationNames.Ventrica__First_Shrine,
+        SceneName = SceneNames.Song_Enclave_Tube,
+        X = 18f,
+        Y = 6f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // 80 rosaries — near tube entrance at (48.01, 4.24)
+    public static Location Ventrica__Choral_Chambers => new CoordinateLocation
+    {
+        Name = LocationNames.Ventrica__Choral_Chambers,
+        SceneName = SceneNames.Song_01b,
+        X = 50f,
+        Y = 4f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // 80 rosaries — near tube entrance at (81.66, 11.28)
+    public static Location Ventrica__Grand_Bellway => new CoordinateLocation
+    {
+        Name = LocationNames.Ventrica__Grand_Bellway,
+        SceneName = SceneNames.Bellway_City,
+        X = 83f,
+        Y = 11f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+
+    // 80 rosaries — near tube entrance at (66.21, 4.25)
+    public static Location Ventrica__Underworks => new CoordinateLocation
+    {
+        Name = LocationNames.Ventrica__Underworks,
+        SceneName = SceneNames.Under_22,
+        X = 68f,
+        Y = 4f,
+        Managed = false,
+    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+}

--- a/ItemChanger.Silksong/RawData/BaseLocationList/FastTravel.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/FastTravel.cs
@@ -41,7 +41,7 @@ internal static partial class BaseLocationList
         X = 86.75f,
         Y = 17.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(40) });
 
     // 40 rosaries
     public static Location Bellway__Far_Fields => new CoordinateLocation
@@ -51,7 +51,7 @@ internal static partial class BaseLocationList
         X = 67.14f,
         Y = 9.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(40) });
 
     // 60 rosaries
     public static Location Bellway__Greymoor => new CoordinateLocation
@@ -61,7 +61,7 @@ internal static partial class BaseLocationList
         X = 66.83f,
         Y = 9.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(60) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(60) });
 
     // 60 rosaries
     public static Location Bellway__Bellhart => new CoordinateLocation
@@ -71,7 +71,7 @@ internal static partial class BaseLocationList
         X = 31.74f,
         Y = 96.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(60) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(60) });
 
     // 40 rosaries
     public static Location Bellway__Shellwood => new CoordinateLocation
@@ -81,7 +81,7 @@ internal static partial class BaseLocationList
         X = 54.91f,
         Y = 6.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(40) });
 
     // 60 rosaries
     public static Location Bellway__Blasted_Steps => new CoordinateLocation
@@ -91,7 +91,7 @@ internal static partial class BaseLocationList
         X = 97.81f,
         Y = 13.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(60) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(60) });
 
     // 40 rosaries
     public static Location Bellway__The_Slab => new CoordinateLocation
@@ -101,7 +101,7 @@ internal static partial class BaseLocationList
         X = 47.95f,
         Y = 6.72f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(40) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(40) });
 
     // 80 rosaries
     public static Location Bellway__Grand_Bellway => new CoordinateLocation
@@ -111,7 +111,7 @@ internal static partial class BaseLocationList
         X = 36.49f,
         Y = 11.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // 80 rosaries
     public static Location Bellway__Bilewater => new CoordinateLocation
@@ -121,7 +121,7 @@ internal static partial class BaseLocationList
         X = 47.90f,
         Y = 22.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // 80 rosaries
     public static Location Bellway__Putrified_Ducts => new CoordinateLocation
@@ -131,7 +131,7 @@ internal static partial class BaseLocationList
         X = 48.56f,
         Y = 22.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // === Ventrica locations ===
 
@@ -153,7 +153,7 @@ internal static partial class BaseLocationList
         X = 20.10f,
         Y = 6.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // 80 rosaries
     public static Location Ventrica__High_Halls => new CoordinateLocation
@@ -163,7 +163,7 @@ internal static partial class BaseLocationList
         X = 28.43f,
         Y = 4.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // 80 rosaries
     public static Location Ventrica__First_Shrine => new CoordinateLocation
@@ -173,7 +173,7 @@ internal static partial class BaseLocationList
         X = 19.27f,
         Y = 6.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // 80 rosaries
     public static Location Ventrica__Choral_Chambers => new CoordinateLocation
@@ -183,7 +183,7 @@ internal static partial class BaseLocationList
         X = 44.28f,
         Y = 4.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // 80 rosaries
     public static Location Ventrica__Grand_Bellway => new CoordinateLocation
@@ -193,7 +193,7 @@ internal static partial class BaseLocationList
         X = 76.61f,
         Y = 11.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 
     // 80 rosaries
     public static Location Ventrica__Underworks => new CoordinateLocation
@@ -203,5 +203,5 @@ internal static partial class BaseLocationList
         X = 69.74f,
         Y = 4.57f,
         Managed = false,
-    }.WithTag(new CostTag { Cost = new RosaryCost(80) });
+    }.WithTag(new DefaultCostTag { Cost = new RosaryCost(80) });
 }

--- a/ItemChangerTesting/MiscTests/FastTravelCoordinateFinder.cs
+++ b/ItemChangerTesting/MiscTests/FastTravelCoordinateFinder.cs
@@ -1,0 +1,132 @@
+using Benchwarp.Data;
+using ItemChanger;
+using ItemChanger.Silksong.RawData;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace ItemChangerTesting.MiscTests;
+
+/// <summary>
+/// Debug test to discover coordinates for fast travel locations.
+/// Logs positions of bell beast / ventrica interact objects and nearby GameObjects on scene load.
+/// Use Benchwarp to visit each scene and read coordinates from BepInEx/LogOutput.log.
+/// </summary>
+internal class FastTravelCoordinateFinder : Test
+{
+    private static readonly HashSet<string> TargetScenes =
+    [
+        // Bellway scenes needing coordinates
+        SceneNames.Bellway_02,          // Deep Docks
+        SceneNames.Bellway_03,          // Far Fields
+        SceneNames.Bellway_04,          // Greymoor
+        SceneNames.Belltown_basement,   // Bellhart
+        SceneNames.Shellwood_19,        // Shellwood
+        SceneNames.Bellway_08,          // Blasted Steps
+        SceneNames.Slab_06,             // The Slab
+        SceneNames.Bellway_City,        // Grand Bellway
+        SceneNames.Bellway_Aqueduct,    // Putrified Ducts
+        // Ventrica scenes needing coordinates
+        SceneNames.Arborium_Tube,       // Memorium
+        SceneNames.Song_Enclave_Tube,   // First Shrine
+        SceneNames.Song_01b,            // Choral Chambers
+        SceneNames.Under_22,            // Underworks
+        // Scenes with known coordinates (for verification)
+        SceneNames.Bellway_01,          // Bone Bottom
+        SceneNames.Bone_05,             // The Marrow
+        SceneNames.Bellway_Shadow,      // Bilewater
+        SceneNames.Tube_Hub,            // Terminus
+        SceneNames.Hang_06b,            // High Halls
+    ];
+
+    // Object name fragments that indicate fast travel interact points
+    private static readonly string[] InterestingNames =
+    [
+        "Beast",        // Bell Beast NPC (e.g. "Bone Beast NPC")
+        "Bell",         // Bell-related objects
+        "Tube",         // Ventrica tube objects
+        "Ventrica",     // Ventrica-related
+        "Station",      // Station objects
+        "FastTravel",   // Fast travel markers
+        "fastTravel",   // Gate name pattern
+        "Interact",     // Interaction triggers
+        "NPC",          // NPC objects that may be bell beasts
+        "Door",         // Transition doors
+    ];
+
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.MiscTests,
+        MenuName = "FT Coord Finder",
+        MenuDescription = "Logs positions of fast travel objects on scene load. Use Benchwarp to visit scenes.",
+        Revision = 2026041500,
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Bellway_01, PrimitiveGateNames.left1);
+    }
+
+    protected override void DoLoad()
+    {
+        base.DoLoad();
+        SceneManager.activeSceneChanged += OnSceneChanged;
+    }
+
+    protected override void DoUnload()
+    {
+        SceneManager.activeSceneChanged -= OnSceneChanged;
+        base.DoUnload();
+    }
+
+    private void OnSceneChanged(Scene from, Scene to)
+    {
+        if (!TargetScenes.Contains(to.name))
+        {
+            return;
+        }
+
+        Log($"=== Fast Travel Coordinate Finder: entered {to.name} ===");
+
+        GameObject[] rootObjects = to.GetRootGameObjects();
+        foreach (GameObject root in rootObjects)
+        {
+            LogInterestingObjects(root.transform, to.name, depth: 0, maxDepth: 3);
+        }
+
+        // Also log the hero position as a reference point
+        GameObject? hero = GameObject.Find("Knight");
+        if (hero != null)
+        {
+            Vector3 pos = hero.transform.position;
+            Log($"  [Hero] position: X={pos.x:F2}, Y={pos.y:F2}, Z={pos.z:F2}");
+        }
+
+        Log($"=== End {to.name} ===");
+    }
+
+    private void LogInterestingObjects(Transform t, string sceneName, int depth, int maxDepth)
+    {
+        string name = t.gameObject.name;
+
+        if (InterestingNames.Any(f => name.Contains(f, StringComparison.OrdinalIgnoreCase)))
+        {
+            Vector3 pos = t.position;
+            string indent = new(' ', depth * 2);
+            string active = t.gameObject.activeInHierarchy ? "" : " [INACTIVE]";
+            Log($"  {indent}{name}{active} — X={pos.x:F2}, Y={pos.y:F2}, Z={pos.z:F2}");
+        }
+
+        if (depth < maxDepth)
+        {
+            for (int i = 0; i < t.childCount; i++)
+            {
+                LogInterestingObjects(t.GetChild(i), sceneName, depth + 1, maxDepth);
+            }
+        }
+    }
+
+    private static void Log(string message)
+    {
+        ItemChangerTestingPlugin.Instance.Logger.LogInfo(message);
+    }
+}

--- a/ItemChangerTesting/MiscTests/FastTravelCoordinateFinder.cs
+++ b/ItemChangerTesting/MiscTests/FastTravelCoordinateFinder.cs
@@ -8,57 +8,52 @@ namespace ItemChangerTesting.MiscTests;
 
 /// <summary>
 /// Debug test to discover coordinates for fast travel locations.
-/// Logs positions of bell beast / ventrica interact objects and nearby GameObjects on scene load.
-/// Use Benchwarp to visit each scene and read coordinates from BepInEx/LogOutput.log.
+/// Logs positions of fast-travel-related GameObjects on scene load, then continuously
+/// logs Hornet's position so you can stand where the check should be and read the
+/// coordinates from BepInEx/LogOutput.log.
 /// </summary>
 internal class FastTravelCoordinateFinder : Test
 {
     private static readonly HashSet<string> TargetScenes =
     [
-        // Bellway scenes needing coordinates
-        SceneNames.Bellway_02,          // Deep Docks
-        SceneNames.Bellway_03,          // Far Fields
-        SceneNames.Bellway_04,          // Greymoor
-        SceneNames.Belltown_basement,   // Bellhart
-        SceneNames.Shellwood_19,        // Shellwood
-        SceneNames.Bellway_08,          // Blasted Steps
-        SceneNames.Slab_06,             // The Slab
-        SceneNames.Bellway_City,        // Grand Bellway
-        SceneNames.Bellway_Aqueduct,    // Putrified Ducts
-        // Ventrica scenes needing coordinates
-        SceneNames.Arborium_Tube,       // Memorium
-        SceneNames.Song_Enclave_Tube,   // First Shrine
-        SceneNames.Song_01b,            // Choral Chambers
-        SceneNames.Under_22,            // Underworks
-        // Scenes with known coordinates (for verification)
-        SceneNames.Bellway_01,          // Bone Bottom
-        SceneNames.Bone_05,             // The Marrow
-        SceneNames.Bellway_Shadow,      // Bilewater
-        SceneNames.Tube_Hub,            // Terminus
-        SceneNames.Hang_06b,            // High Halls
+        SceneNames.Bellway_01,          // Bone Bottom (free)
+        SceneNames.Bone_05,              // The Marrow (free)
+        SceneNames.Bellway_02,           // Deep Docks
+        SceneNames.Bellway_03,           // Far Fields
+        SceneNames.Bellway_04,           // Greymoor
+        SceneNames.Belltown_basement,    // Bellhart
+        SceneNames.Shellwood_19,         // Shellwood
+        SceneNames.Bellway_08,           // Blasted Steps
+        SceneNames.Slab_06,              // The Slab
+        SceneNames.Bellway_City,         // Grand Bellway (Bellway + Ventrica)
+        SceneNames.Bellway_Shadow,       // Bilewater
+        SceneNames.Bellway_Aqueduct,     // Putrified Ducts
+        SceneNames.Tube_Hub,             // Terminus (free)
+        SceneNames.Arborium_Tube,        // Memorium
+        SceneNames.Hang_06b,             // High Halls
+        SceneNames.Song_Enclave_Tube,    // First Shrine
+        SceneNames.Song_01b,             // Choral Chambers
+        SceneNames.Under_22,             // Underworks
     ];
 
-    // Object name fragments that indicate fast travel interact points
     private static readonly string[] InterestingNames =
     [
-        "Beast",        // Bell Beast NPC (e.g. "Bone Beast NPC")
-        "Bell",         // Bell-related objects
-        "Tube",         // Ventrica tube objects
-        "Ventrica",     // Ventrica-related
-        "Station",      // Station objects
-        "FastTravel",   // Fast travel markers
-        "fastTravel",   // Gate name pattern
-        "Interact",     // Interaction triggers
-        "NPC",          // NPC objects that may be bell beasts
-        "Door",         // Transition doors
+        "Toll Machine",
+        "door_fastTravel",
+        "door_tubeEnter",
+        "Beast NPC",
+        "Bellway_station",
+        "bellway_platform",
     ];
+
+    private GameObject? _tracker;
 
     public override TestMetadata GetMetadata() => new()
     {
         Folder = TestFolder.MiscTests,
         MenuName = "FT Coord Finder",
-        MenuDescription = "Logs positions of fast travel objects on scene load. Use Benchwarp to visit scenes.",
-        Revision = 2026041500,
+        MenuDescription = "Stand where the check should be — Hornet's position is logged every 2s.",
+        Revision = 2026041600,
     };
 
     public override void Setup(TestArgs args)
@@ -70,63 +65,83 @@ internal class FastTravelCoordinateFinder : Test
     {
         base.DoLoad();
         SceneManager.activeSceneChanged += OnSceneChanged;
+        _tracker = new GameObject("FastTravelCoordTracker");
+        UObject.DontDestroyOnLoad(_tracker);
+        _tracker.AddComponent<HornetPositionLogger>();
     }
 
     protected override void DoUnload()
     {
         SceneManager.activeSceneChanged -= OnSceneChanged;
+        if (_tracker != null)
+        {
+            UObject.Destroy(_tracker);
+            _tracker = null;
+        }
         base.DoUnload();
     }
 
     private void OnSceneChanged(Scene from, Scene to)
     {
-        if (!TargetScenes.Contains(to.name))
+        if (!TargetScenes.Contains(to.name)) return;
+
+        Log($"=== Entered {to.name} ===");
+        foreach (GameObject root in to.GetRootGameObjects())
         {
-            return;
+            LogInterestingObjects(root.transform, depth: 0, maxDepth: 4);
         }
-
-        Log($"=== Fast Travel Coordinate Finder: entered {to.name} ===");
-
-        GameObject[] rootObjects = to.GetRootGameObjects();
-        foreach (GameObject root in rootObjects)
-        {
-            LogInterestingObjects(root.transform, to.name, depth: 0, maxDepth: 3);
-        }
-
-        // Also log the hero position as a reference point
-        GameObject? hero = GameObject.Find("Knight");
-        if (hero != null)
-        {
-            Vector3 pos = hero.transform.position;
-            Log($"  [Hero] position: X={pos.x:F2}, Y={pos.y:F2}, Z={pos.z:F2}");
-        }
-
-        Log($"=== End {to.name} ===");
     }
 
-    private void LogInterestingObjects(Transform t, string sceneName, int depth, int maxDepth)
+    private void LogInterestingObjects(Transform t, int depth, int maxDepth)
     {
         string name = t.gameObject.name;
-
         if (InterestingNames.Any(f => name.Contains(f, StringComparison.OrdinalIgnoreCase)))
         {
             Vector3 pos = t.position;
             string indent = new(' ', depth * 2);
             string active = t.gameObject.activeInHierarchy ? "" : " [INACTIVE]";
-            Log($"  {indent}{name}{active} — X={pos.x:F2}, Y={pos.y:F2}, Z={pos.z:F2}");
+            Log($"  {indent}{name}{active} — X={pos.x:F2}, Y={pos.y:F2}");
         }
 
         if (depth < maxDepth)
         {
             for (int i = 0; i < t.childCount; i++)
             {
-                LogInterestingObjects(t.GetChild(i), sceneName, depth + 1, maxDepth);
+                LogInterestingObjects(t.GetChild(i), depth + 1, maxDepth);
             }
         }
     }
 
-    private static void Log(string message)
-    {
+    internal static void Log(string message) =>
         ItemChangerTestingPlugin.Instance.Logger.LogInfo(message);
+}
+
+internal class HornetPositionLogger : MonoBehaviour
+{
+    private const float LogIntervalSeconds = 2f;
+    private float _nextLogTime;
+    private Vector3 _lastLoggedPosition = Vector3.positiveInfinity;
+
+    private void Update()
+    {
+        if (Time.unscaledTime < _nextLogTime) return;
+
+        HeroController? hero = HeroController.instance;
+        if (hero == null) return;
+
+        Vector3 pos = hero.transform.position;
+
+        // Only log if position changed meaningfully (avoid spam when standing still)
+        if (Vector3.Distance(pos, _lastLoggedPosition) < 0.05f)
+        {
+            _nextLogTime = Time.unscaledTime + LogIntervalSeconds;
+            return;
+        }
+
+        string scene = hero.gameObject.scene.IsValid() ? hero.gameObject.scene.name : "?";
+        FastTravelCoordinateFinder.Log($"  [Hornet @ {scene}] X={pos.x:F2}, Y={pos.y:F2}");
+
+        _lastLoggedPosition = pos;
+        _nextLogTime = Time.unscaledTime + LogIntervalSeconds;
     }
 }

--- a/ItemChangerTesting/ModuleTests/FastTravelTest.cs
+++ b/ItemChangerTesting/ModuleTests/FastTravelTest.cs
@@ -1,7 +1,5 @@
 ﻿using Benchwarp.Data;
 using ItemChanger;
-using ItemChanger.Locations;
-using ItemChanger.Placements;
 using ItemChanger.Silksong.Modules.FastTravel;
 using ItemChanger.Silksong.RawData;
 
@@ -14,83 +12,53 @@ internal class FastTravelTest : Test
         Folder = TestFolder.ModuleTests,
         MenuName = "Fast Travel",
         MenuDescription = "Tests the fast travel stuff",
-        Revision = 2026021400,
+        Revision = 2026041500,
     };
+
+    private static readonly string[] AllBellways =
+    [
+        LocationNames.Bellway__Bone_Bottom,
+        LocationNames.Bellway__The_Marrow,
+        LocationNames.Bellway__Deep_Docks,
+        LocationNames.Bellway__Far_Fields,
+        LocationNames.Bellway__Greymoor,
+        LocationNames.Bellway__Bellhart,
+        LocationNames.Bellway__Shellwood,
+        LocationNames.Bellway__Blasted_Steps,
+        LocationNames.Bellway__The_Slab,
+        LocationNames.Bellway__Grand_Bellway,
+        LocationNames.Bellway__Bilewater,
+        LocationNames.Bellway__Putrified_Ducts,
+    ];
+
+    private static readonly string[] AllVentricas =
+    [
+        LocationNames.Ventrica__Terminus,
+        LocationNames.Ventrica__Memorium,
+        LocationNames.Ventrica__High_Halls,
+        LocationNames.Ventrica__First_Shrine,
+        LocationNames.Ventrica__Choral_Chambers,
+        LocationNames.Ventrica__Grand_Bellway,
+        LocationNames.Ventrica__Underworks,
+    ];
 
     public override void Setup(TestArgs args)
     {
-        StartNear(SceneNames.Bellway_Shadow, PrimitiveGateNames.left1);
+        StartNear(SceneNames.Bellway_01, PrimitiveGateNames.left1);
 
-        // Add modules
         Modules.CreateBellwayModules();
         Modules.CreateVentricaModules();
 
+        foreach (string name in AllBellways)
         {
-            // Add location to test unlocking a bellway in the correct scene
-            Placement pmt = new CoordinateLocation()
-            {
-                Name = "Bellway Shadow location",
-                Managed = false,
-                SceneName = SceneNames.Bellway_Shadow,
-                X = 44.11f,
-                Y = 22.57f,
-            }.Wrap()
-             .Add(Finder.GetItem(ItemNames.Bellway__Bilewater)!);
-            Profile.AddPlacement(pmt);
+            Profile.AddPlacement(Finder.GetLocation(name)!.Wrap()
+                .Add(Finder.GetItem(name)!));
         }
 
+        foreach (string name in AllVentricas)
         {
-            // Add locations for bone bottom and marrow bellways
-            Placement pmt = new CoordinateLocation()
-            {
-                Name = "Bellway Bonebottom location",
-                Managed = false,
-                SceneName = SceneNames.Bellway_01,
-                X = 52.37f,
-                Y = 21.59f,
-            }.Wrap()
-             .Add(Finder.GetItem(ItemNames.Bellway__Bone_Bottom)!);
-            Profile.AddPlacement(pmt);
-        }
-
-        {
-            // Add locations for bone bottom and marrow bellways
-            Placement pmt = new CoordinateLocation()
-            {
-                Name = "Bellway Marrow location",
-                Managed = false,
-                SceneName = SceneNames.Bone_05,
-                X = 137.18f,
-                Y = 4.57f,
-            }.Wrap()
-             .Add(Finder.GetItem(ItemNames.Bellway__The_Marrow)!);
-            Profile.AddPlacement(pmt);
-        }
-
-        {
-            Placement pmt = new CoordinateLocation()
-            {
-                Name = "Ventrica Terminus location",
-                Managed = false,
-                SceneName = SceneNames.Tube_Hub,
-                X = 68.77f,
-                Y = 39.57f,
-            }.Wrap()
-             .Add(Finder.GetItem(ItemNames.Ventrica__Terminus)!);
-            Profile.AddPlacement(pmt);
-        }
-
-        {
-            Placement pmt = new CoordinateLocation()
-            {
-                Name = "Ventrica Hang location",
-                Managed = false,
-                SceneName = SceneNames.Hang_06b,
-                X = 23.14f,
-                Y = 4.57f,
-            }.Wrap()
-             .Add(Finder.GetItem(ItemNames.Ventrica__High_Halls)!);
-            Profile.AddPlacement(pmt);
+            Profile.AddPlacement(Finder.GetLocation(name)!.Wrap()
+                .Add(Finder.GetItem(name)!));
         }
     }
 }


### PR DESCRIPTION
Add 19 fast travel locations (12 Bellway + 7 Ventrica) as CoordinateLocations with CostTags matching base game rosary costs. Coordinates placed near Toll Machine / tube entrance interact points in each scene. Reused coordinates from previous fast travel location test.

Update FastTravelTest to exercise all 19 locations via Finder.GetLocation(). Add FastTravelCoordinateFinder debug test for discovering object positions.