### PR TITLE
Add Grounded Sprint novelty item (#52)

### DIFF
--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -11,10 +11,13 @@ namespace ItemChanger.Silksong.Modules.CustomSkills;
 /// flibber (#209): trick the game so vanilla sprint anim/cState run.
 ///
 /// Playtest fixes:
-/// - Ledge fall: hard cancel + clamp air horizontal speed to walk.
+/// - Ledge fall: soft cancel + clamp air horizontal speed to walk.
 /// - Wall clip: never allow real HeroDash for GS-only.
 /// - Ground dash still worked: Prepatcher makes playerData.hasDash use GetBool, so
 ///   spoofing hasDash made CanDash true. Force CanDash false and block HeroDash*.
+/// - Jump-from-sprint / downslash: never send HARD LANDING (kills jump Y and interrupts
+///   air attacks). Only CANCEL SPRINT + flag clear, and only on leave-ground / jump —
+///   not every airborne frame.
 /// </summary>
 public class GroundedSprintModule : CustomSkillModule
 {
@@ -237,12 +240,14 @@ public class GroundedSprintModule : CustomSkillModule
     private static void HeroJumpBoolPrefix(HeroController __instance, ref bool checkSprint)
     {
         if (!OnlyGroundedSprintKit()) return;
+        // Disable shuttlecock path without wrecking jump velocity.
         checkSprint = false;
         __instance.PreventShuttlecock();
         SprintBufferStepsField?.SetValue(__instance, 0);
         SyncBufferStepsField?.SetValue(__instance, false);
         NoShuttlecockTimeField?.SetValue(__instance, Time.timeAsDouble + 5.0);
-        CancelSprintHard(__instance, clampAirSpeed: false);
+        // Soft cancel only — HARD LANDING / air clamp here was killing jump height.
+        SoftCancelSprint(__instance, sendFsmEvent: true, clampAirSpeed: false);
     }
 
     /// <summary>Before LeftGround fills sprintBufferSteps from isSprinting/dashing.</summary>
@@ -259,7 +264,7 @@ public class GroundedSprintModule : CustomSkillModule
     private static void LeftGroundPostfix(HeroController __instance)
     {
         if (!OnlyGroundedSprintKit()) return;
-        CancelSprintHard(__instance, clampAirSpeed: true);
+        SoftCancelSprint(__instance, sendFsmEvent: true, clampAirSpeed: true);
     }
 
     private static void HeroUpdatePostfix(HeroController __instance) => TickGuards(__instance, physics: false);
@@ -278,15 +283,21 @@ public class GroundedSprintModule : CustomSkillModule
 
         bool grounded = IsEffectivelyGrounded(hc);
 
-        // Edge: just left ground (ledge or jump) — cancel immediately.
+        // Edge: just left ground (ledge or jump) — one soft cancel, not HARD LANDING.
         if (_wasOnGround && !grounded)
-            CancelSprintHard(hc, clampAirSpeed: true);
+            SoftCancelSprint(hc, sendFsmEvent: true, clampAirSpeed: true);
 
         _wasOnGround = grounded;
 
         if (!grounded)
         {
-            CancelSprintHard(hc, clampAirSpeed: true);
+            // Maintain no-sprint midair without re-firing FSM events every frame
+            // (HARD LANDING spam broke jump height + downslash).
+            if (hc.cState.isSprinting || hc.cState.isBackSprinting)
+                SoftCancelSprint(hc, sendFsmEvent: true, clampAirSpeed: true);
+            else
+                ClearSprintSpeedAdd(hc);
+
             if (physics)
                 ClampAirHorizontalSpeed(hc);
             return;
@@ -303,14 +314,17 @@ public class GroundedSprintModule : CustomSkillModule
         }
     }
 
-    private static void CancelSprintHard(HeroController hc, bool clampAirSpeed)
+    /// <summary>
+    /// End sprint cleanly. Never send HARD LANDING — that event aborts jump impulse
+    /// and interrupts aerial attacks (downslash).
+    /// </summary>
+    private static void SoftCancelSprint(HeroController hc, bool sendFsmEvent, bool clampAirSpeed)
     {
         SprintBufferStepsField?.SetValue(hc, 0);
         SyncBufferStepsField?.SetValue(hc, false);
 
-        hc.sprintFSM?.SendEvent("CANCEL SPRINT");
-        // Extra cancel events some sprint substates listen for
-        hc.sprintFSM?.SendEvent("HARD LANDING");
+        if (sendFsmEvent)
+            hc.sprintFSM?.SendEvent("CANCEL SPRINT");
 
         hc.cState.isSprinting = false;
         hc.cState.isBackSprinting = false;
@@ -321,11 +335,16 @@ public class GroundedSprintModule : CustomSkillModule
             if (isSprint != null) isSprint.Value = false;
         }
 
-        if (SprintSpeedAddFloatField?.GetValue(hc) is HutongGames.PlayMaker.FsmFloat add)
-            add.Value = 0f;
+        ClearSprintSpeedAdd(hc);
 
         if (clampAirSpeed && !IsEffectivelyGrounded(hc))
             ClampAirHorizontalSpeed(hc);
+    }
+
+    private static void ClearSprintSpeedAdd(HeroController hc)
+    {
+        if (SprintSpeedAddFloatField?.GetValue(hc) is HutongGames.PlayMaker.FsmFloat add)
+            add.Value = 0f;
     }
 
     /// <summary>

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -1,23 +1,23 @@
 using HarmonyLib;
 using ItemChanger.Silksong.Extensions;
 using System.Reflection;
+using UnityEngine;
 
 namespace ItemChanger.Silksong.Modules.CustomSkills;
 
 /// <summary>
-/// Novelty: Swift Step sprint while grounded, without air dash / air sprint for logic.
+/// Novelty: Swift Step sprint while grounded, without air dash / air sprint / shuttle-cock.
 ///
-/// flibber (#209): trick the game into thinking the player has dash at the right times
-/// so vanilla animations and cState work — not a GetRunSpeed speed hack.
+/// flibber (#209): trick the game so vanilla sprint anim/cState run — not a GetRunSpeed hack.
 ///
-/// Silksong path (decomp): Dash.WasPressed → CanDash() [field hasDash] → HeroDash →
-/// sprintFSM "DASHED" → FinishedDashing → "TRY SPRINT". Sprint speed is FSM "Add Speed",
-/// not GetRunSpeed. There is no PlayerDataBoolTest(hasDash) on sprintFSM.
+/// Silksong path: CanDash (field hasDash) → HeroDash → sprintFSM DASHED → TRY SPRINT.
+/// Sprint speed is FSM "Add Speed". CanDash is postfixed true only on ground for GS-only.
 ///
-/// We:
-/// 1) Spoof GetBool("hasDash") while grounded + owned (CustomSkillPlayerDataModule)
-/// 2) Postfix CanDash so ground dash→sprint can start (field hasDash stays false for air)
-/// 3) Cancel sprint / clear buffer / PreventShuttlecock in air
+/// Air / shuttle-cock (playtest failures):
+/// - Prefix OnShuttleCockJump to skip entirely for GS-only kit
+/// - Prefix HeroJump(bool) forces checkSprint=false
+/// - PreventShuttlecock every frame while GS-only (covers dashing→jump)
+/// - Air: CANCEL SPRINT, clear cState sprint flags, zero buffer + Add Speed
 /// </summary>
 public class GroundedSprintModule : CustomSkillModule
 {
@@ -31,14 +31,16 @@ public class GroundedSprintModule : CustomSkillModule
     private static readonly FieldInfo? HasDashField =
         AccessTools.Field(typeof(PlayerData), "hasDash")
         ?? AccessTools.DeclaredField(typeof(PlayerData), "hasDash");
+    private static readonly FieldInfo? SprintSpeedAddFloatField =
+        AccessTools.Field(typeof(HeroController), "sprintSpeedAddFloat");
+    private static readonly FieldInfo? NoShuttlecockTimeField =
+        AccessTools.Field(typeof(HeroController), "noShuttlecockTime");
 
     private Harmony? _harmony;
 
     public override IEnumerable<string> GettableSkillBools() =>
     [
         nameof(hasGroundedSprint),
-        // GetPlayerDataBool / PlayMaker path (and inventory tests via GetBool).
-        // Conflicts with SplitSwiftStep if both register hasDash — rare; log error on load.
         nameof(PlayerData.hasDash),
     ];
 
@@ -63,9 +65,6 @@ public class GroundedSprintModule : CustomSkillModule
         }
     }
 
-    /// <summary>
-    /// True if real Swift Step (field) or Grounded Sprint while on the ground.
-    /// </summary>
     private bool ComputeEffectiveHasDash()
     {
         if (ReadRawHasDash()) return true;
@@ -74,7 +73,6 @@ public class GroundedSprintModule : CustomSkillModule
         return hc != null && hc.cState.onGround;
     }
 
-    /// <summary>True field ownership — never call GetBool (recursion).</summary>
     private static bool ReadRawHasDash()
     {
         PlayerData? pd = PlayerData.instance;
@@ -91,67 +89,66 @@ public class GroundedSprintModule : CustomSkillModule
         return !ReadRawHasDash();
     }
 
-    private static bool GroundedSprintActiveOnGround()
-    {
-        if (!OnlyGroundedSprintKit()) return false;
-        HeroController? hc = HeroController.SilentInstance;
-        return hc != null && hc.cState.onGround;
-    }
-
     protected override void DoLoad()
     {
         base.DoLoad();
         _activeInstance = this;
 
-        // Inventory: show sprint-related entries when GS owned (stable, not ground-gated).
         Using(Md.InventoryItemConditional.Evaluate.Prefix(OverrideInventoryDisplayTest));
 
         _harmony = new Harmony("itemchanger.silksong.groundedsprint");
 
-        // CanDash uses field hasDash — must postfix so ground dash→sprint can start.
-        MethodInfo? canDash = AccessTools.Method(typeof(HeroController), nameof(HeroController.CanDash));
-        if (canDash != null)
-        {
-            _harmony.Patch(canDash,
-                postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(CanDashPostfix)));
-        }
-        else
-        {
-            ItemChangerPlugin.Instance.Logger.LogWarning("[GroundedSprint] CanDash not found.");
-        }
+        Patch(typeof(HeroController), nameof(HeroController.CanDash),
+            postfix: nameof(CanDashPostfix));
 
-        MethodInfo? update = AccessTools.Method(typeof(HeroController), "Update");
-        if (update != null)
-        {
-            _harmony.Patch(update,
-                postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroUpdatePostfix)));
-        }
+        // Private Update — per-frame air cancel + continuous shuttlecock block
+        Patch(typeof(HeroController), "Update", postfix: nameof(HeroUpdatePostfix));
+        Patch(typeof(HeroController), "FixedUpdate", postfix: nameof(HeroFixedUpdatePostfix));
 
-        MethodInfo? leftGround = AccessTools.Method(typeof(HeroController), "LeftGround", [typeof(bool)]);
+        // LeftGround fills sprintBufferSteps when isSprinting/dashing — zero after.
+        var leftGround = AccessTools.Method(typeof(HeroController), "LeftGround", [typeof(bool)]);
         if (leftGround != null)
         {
             _harmony.Patch(leftGround,
                 postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(LeftGroundPostfix)));
         }
-        else
-        {
-            MethodInfo? becomeAirborne = AccessTools.Method(typeof(HeroController), "BecomeAirborne");
-            if (becomeAirborne != null)
-            {
-                _harmony.Patch(becomeAirborne,
-                    postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(LeftGroundPostfix)));
-            }
-        }
 
-        MethodInfo? heroJumpBool = AccessTools.Method(typeof(HeroController), "HeroJump", [typeof(bool)]);
+        // HeroJump(bool): collapse checkSprint
+        var heroJumpBool = AccessTools.Method(typeof(HeroController), "HeroJump", [typeof(bool)]);
         if (heroJumpBool != null)
         {
             _harmony.Patch(heroJumpBool,
                 prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroJumpBoolPrefix)));
         }
 
+        // Hard block: skip OnShuttleCockJump body entirely for GS-only
+        var shuttle = AccessTools.Method(typeof(HeroController), "OnShuttleCockJump");
+        if (shuttle != null)
+        {
+            _harmony.Patch(shuttle,
+                prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(OnShuttleCockJumpPrefix)));
+        }
+        else
+        {
+            ItemChangerPlugin.Instance.Logger.LogWarning(
+                "[GroundedSprint] OnShuttleCockJump not found — shuttlecock may still fire.");
+        }
+
         ItemChangerPlugin.Instance.Logger.LogInfo(
-            "[GroundedSprint] loaded: CanDash/GetBool grounded spoof + air cancel guards.");
+            "[GroundedSprint] loaded: grounded CanDash/GetBool + hard shuttlecock skip + air cancel.");
+    }
+
+    private void Patch(Type type, string name, string? prefix = null, string? postfix = null)
+    {
+        MethodInfo? m = AccessTools.Method(type, name);
+        if (m == null)
+        {
+            ItemChangerPlugin.Instance.Logger.LogWarning($"[GroundedSprint] method not found: {type.Name}.{name}");
+            return;
+        }
+        _harmony!.Patch(m,
+            prefix: prefix != null ? new HarmonyMethod(typeof(GroundedSprintModule), prefix) : null,
+            postfix: postfix != null ? new HarmonyMethod(typeof(GroundedSprintModule), postfix) : null);
     }
 
     protected override void DoUnload()
@@ -175,60 +172,92 @@ public class GroundedSprintModule : CustomSkillModule
         }
     }
 
-    // ---- Harmony ----
+    // ---- Harmony targets ----
 
-    /// <summary>
-    /// Field hasDash is false for GS-only. Allow CanDash on ground so HeroDash → DASHED → sprint runs.
-    /// Air stays false → no air dash.
-    /// </summary>
     private static void CanDashPostfix(HeroController __instance, ref bool __result)
     {
         if (__result) return;
         if (!OnlyGroundedSprintKit()) return;
         if (!__instance.cState.onGround) return;
-        // Match other CanDash gates loosely: no hazard death, allow input path.
         if (__instance.cState.hazardDeath) return;
         __result = true;
     }
 
-    private static void HeroUpdatePostfix(HeroController __instance)
+    /// <summary>Harmony prefix: return false to skip original OnShuttleCockJump.</summary>
+    private static bool OnShuttleCockJumpPrefix()
+    {
+        if (!OnlyGroundedSprintKit()) return true; // run original
+        return false; // skip — no shuttle-cock for GS-only
+    }
+
+    private static void HeroJumpBoolPrefix(HeroController __instance, ref bool checkSprint)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+        checkSprint = false;
+        // Belt-and-suspenders: keep prevent window open and clear buffer before jump body.
+        __instance.PreventShuttlecock();
+        SprintBufferStepsField?.SetValue(__instance, 0);
+        // Far-future prevent in case PreventShuttlecock window is too short during frame spikes
+        NoShuttlecockTimeField?.SetValue(__instance, Time.timeAsDouble + 5.0);
+    }
+
+    private static void HeroUpdatePostfix(HeroController __instance) => TickGroundedSprintGuards(__instance);
+    private static void HeroFixedUpdatePostfix(HeroController __instance) => TickGroundedSprintGuards(__instance);
+
+    private static void TickGroundedSprintGuards(HeroController hc)
     {
         if (!OnlyGroundedSprintKit()) return;
 
-        if (!__instance.cState.onGround)
+        // Always keep shuttlecock blocked while GS-only (covers dashing frames before isSprinting).
+        hc.PreventShuttlecock();
+        NoShuttlecockTimeField?.SetValue(hc, Time.timeAsDouble + 1.0);
+
+        if (!hc.cState.onGround)
         {
-            if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
-                __instance.sprintFSM?.SendEvent("CANCEL SPRINT");
-            SprintBufferStepsField?.SetValue(__instance, 0);
+            CancelSprintHard(hc);
             return;
         }
 
-        // Also poke TRY SPRINT while holding dash on ground if not already sprinting/dashing,
-        // so hold-to-sprint works even when a full dash burst is interrupted.
+        // Hold-dash on ground: poke TRY SPRINT if idle walk (FSM may need the nudge).
         if (InputHandler.Instance != null
             && InputHandler.Instance.inputActions.Dash.IsPressed
-            && !__instance.cState.dashing
-            && !__instance.cState.isSprinting
-            && __instance.CanSprint())
+            && !hc.cState.dashing
+            && !hc.cState.isSprinting
+            && !hc.cState.isBackSprinting
+            && hc.CanSprint())
         {
-            __instance.sprintFSM?.SendEvent("TRY SPRINT");
+            hc.sprintFSM?.SendEvent("TRY SPRINT");
         }
-
-        if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
-            __instance.PreventShuttlecock();
     }
 
     private static void LeftGroundPostfix(HeroController __instance)
     {
         if (!OnlyGroundedSprintKit()) return;
-        SprintBufferStepsField?.SetValue(__instance, 0);
-        if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
-            __instance.sprintFSM?.SendEvent("CANCEL SPRINT");
+        CancelSprintHard(__instance);
     }
 
-    private static void HeroJumpBoolPrefix(ref bool checkSprint)
+    /// <summary>
+    /// Force end of sprint state for GS-only: FSM event + cState + buffer + Add Speed float.
+    /// </summary>
+    private static void CancelSprintHard(HeroController hc)
     {
-        if (!OnlyGroundedSprintKit()) return;
-        checkSprint = false;
+        SprintBufferStepsField?.SetValue(hc, 0);
+
+        bool wasSprinting = hc.cState.isSprinting
+            || hc.cState.isBackSprinting
+            || hc.cState.isBackScuttling
+            || (hc.sprintFSM != null && hc.sprintFSM.FsmVariables.GetFsmBool("Is Sprinting") is { } b && b.Value);
+
+        if (wasSprinting || !hc.cState.onGround)
+        {
+            hc.sprintFSM?.SendEvent("CANCEL SPRINT");
+            // Direct cState clear if FSM is slow a frame
+            hc.cState.isSprinting = false;
+            hc.cState.isBackSprinting = false;
+        }
+
+        // Zero sprint speed add so residual velocity doesn't linger mid-air
+        if (SprintSpeedAddFloatField?.GetValue(hc) is HutongGames.PlayMaker.FsmFloat add)
+            add.Value = 0f;
     }
 }

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -6,18 +6,15 @@ using UnityEngine;
 namespace ItemChanger.Silksong.Modules.CustomSkills;
 
 /// <summary>
-/// Novelty: Swift Step sprint while grounded, without air dash / air sprint / shuttle-cock.
+/// Novelty: Swift Step sprint while grounded only — no air sprint, no air dash, no shuttle-cock.
 ///
-/// flibber (#209): trick the game so vanilla sprint anim/cState run — not a GetRunSpeed hack.
+/// flibber (#209): trick the game so vanilla sprint anim/cState run.
 ///
-/// Silksong path: CanDash (field hasDash) → HeroDash → sprintFSM DASHED → TRY SPRINT.
-/// Sprint speed is FSM "Add Speed". CanDash is postfixed true only on ground for GS-only.
-///
-/// Air / shuttle-cock (playtest failures):
-/// - Prefix OnShuttleCockJump to skip entirely for GS-only kit
-/// - Prefix HeroJump(bool) forces checkSprint=false
-/// - PreventShuttlecock every frame while GS-only (covers dashing→jump)
-/// - Air: CANCEL SPRINT, clear cState sprint flags, zero buffer + Add Speed
+/// Playtest fixes:
+/// - Ledge fall kept sprinting: CANCEL SPRINT alone is not enough; clamp air horizontal
+///   speed to walk and zero FSM Add Speed every physics tick while airborne.
+/// - Wall clip on turn+jump: do NOT spoof CanDash (that starts a real ground dash into
+///   walls). Enter sprint only via TRY SPRINT + GetBool("hasDash") while grounded.
 /// </summary>
 public class GroundedSprintModule : CustomSkillModule
 {
@@ -35,8 +32,11 @@ public class GroundedSprintModule : CustomSkillModule
         AccessTools.Field(typeof(HeroController), "sprintSpeedAddFloat");
     private static readonly FieldInfo? NoShuttlecockTimeField =
         AccessTools.Field(typeof(HeroController), "noShuttlecockTime");
+    private static readonly FieldInfo? SyncBufferStepsField =
+        AccessTools.Field(typeof(HeroController), "syncBufferSteps");
 
     private Harmony? _harmony;
+    private static bool _wasOnGround = true;
 
     public override IEnumerable<string> GettableSkillBools() =>
     [
@@ -69,8 +69,9 @@ public class GroundedSprintModule : CustomSkillModule
     {
         if (ReadRawHasDash()) return true;
         if (!hasGroundedSprint) return false;
+        // Strict ground only — false the instant we leave ground so FSM gates flip.
         HeroController? hc = HeroController.SilentInstance;
-        return hc != null && hc.cState.onGround;
+        return hc != null && IsEffectivelyGrounded(hc);
     }
 
     private static bool ReadRawHasDash()
@@ -89,31 +90,51 @@ public class GroundedSprintModule : CustomSkillModule
         return !ReadRawHasDash();
     }
 
+    /// <summary>
+    /// Grounded for GS purposes: onGround flag OR still touching floor this frame.
+    /// Leaving ledge often has a frame where velocity is high but flag lags — treat
+    /// !CheckTouchingGround as air for cancel/clamp.
+    /// </summary>
+    private static bool IsEffectivelyGrounded(HeroController hc)
+    {
+        if (hc.cState.onGround) return true;
+        // Don't treat wall-slide as ground sprint surface
+        if (hc.cState.wallSliding || hc.cState.wallClinging || hc.cState.wallScrambling)
+            return false;
+        try
+        {
+            return hc.CheckTouchingGround();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     protected override void DoLoad()
     {
         base.DoLoad();
         _activeInstance = this;
+        _wasOnGround = true;
 
         Using(Md.InventoryItemConditional.Evaluate.Prefix(OverrideInventoryDisplayTest));
 
         _harmony = new Harmony("itemchanger.silksong.groundedsprint");
 
-        Patch(typeof(HeroController), nameof(HeroController.CanDash),
-            postfix: nameof(CanDashPostfix));
+        // Intentionally NOT spoofing CanDash — that starts a real ground dash and caused
+        // wall clips on turn+jump. Sprint entry is TRY SPRINT + GetBool hasDash only.
 
-        // Private Update — per-frame air cancel + continuous shuttlecock block
         Patch(typeof(HeroController), "Update", postfix: nameof(HeroUpdatePostfix));
         Patch(typeof(HeroController), "FixedUpdate", postfix: nameof(HeroFixedUpdatePostfix));
 
-        // LeftGround fills sprintBufferSteps when isSprinting/dashing — zero after.
         var leftGround = AccessTools.Method(typeof(HeroController), "LeftGround", [typeof(bool)]);
         if (leftGround != null)
         {
             _harmony.Patch(leftGround,
+                prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(LeftGroundPrefix)),
                 postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(LeftGroundPostfix)));
         }
 
-        // HeroJump(bool): collapse checkSprint
         var heroJumpBool = AccessTools.Method(typeof(HeroController), "HeroJump", [typeof(bool)]);
         if (heroJumpBool != null)
         {
@@ -121,21 +142,15 @@ public class GroundedSprintModule : CustomSkillModule
                 prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroJumpBoolPrefix)));
         }
 
-        // Hard block: skip OnShuttleCockJump body entirely for GS-only
         var shuttle = AccessTools.Method(typeof(HeroController), "OnShuttleCockJump");
         if (shuttle != null)
         {
             _harmony.Patch(shuttle,
                 prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(OnShuttleCockJumpPrefix)));
         }
-        else
-        {
-            ItemChangerPlugin.Instance.Logger.LogWarning(
-                "[GroundedSprint] OnShuttleCockJump not found — shuttlecock may still fire.");
-        }
 
         ItemChangerPlugin.Instance.Logger.LogInfo(
-            "[GroundedSprint] loaded: grounded CanDash/GetBool + hard shuttlecock skip + air cancel.");
+            "[GroundedSprint] loaded: GetBool grounded hasDash, TRY SPRINT only (no CanDash), hard air clamp.");
     }
 
     private void Patch(Type type, string name, string? prefix = null, string? postfix = null)
@@ -172,92 +187,120 @@ public class GroundedSprintModule : CustomSkillModule
         }
     }
 
-    // ---- Harmony targets ----
+    // ---- Harmony ----
 
-    private static void CanDashPostfix(HeroController __instance, ref bool __result)
-    {
-        if (__result) return;
-        if (!OnlyGroundedSprintKit()) return;
-        if (!__instance.cState.onGround) return;
-        if (__instance.cState.hazardDeath) return;
-        __result = true;
-    }
-
-    /// <summary>Harmony prefix: return false to skip original OnShuttleCockJump.</summary>
-    private static bool OnShuttleCockJumpPrefix()
-    {
-        if (!OnlyGroundedSprintKit()) return true; // run original
-        return false; // skip — no shuttle-cock for GS-only
-    }
+    private static bool OnShuttleCockJumpPrefix() => !OnlyGroundedSprintKit();
 
     private static void HeroJumpBoolPrefix(HeroController __instance, ref bool checkSprint)
     {
         if (!OnlyGroundedSprintKit()) return;
         checkSprint = false;
-        // Belt-and-suspenders: keep prevent window open and clear buffer before jump body.
         __instance.PreventShuttlecock();
         SprintBufferStepsField?.SetValue(__instance, 0);
-        // Far-future prevent in case PreventShuttlecock window is too short during frame spikes
+        SyncBufferStepsField?.SetValue(__instance, false);
         NoShuttlecockTimeField?.SetValue(__instance, Time.timeAsDouble + 5.0);
+        CancelSprintHard(__instance, clampAirSpeed: false);
     }
 
-    private static void HeroUpdatePostfix(HeroController __instance) => TickGroundedSprintGuards(__instance);
-    private static void HeroFixedUpdatePostfix(HeroController __instance) => TickGroundedSprintGuards(__instance);
-
-    private static void TickGroundedSprintGuards(HeroController hc)
+    /// <summary>Before LeftGround fills sprintBufferSteps from isSprinting/dashing.</summary>
+    private static void LeftGroundPrefix(HeroController __instance)
     {
         if (!OnlyGroundedSprintKit()) return;
+        // Clear sprint flags BEFORE vanilla buffer fill (uses isSprinting || dashing).
+        __instance.cState.isSprinting = false;
+        __instance.cState.isBackSprinting = false;
+        SprintBufferStepsField?.SetValue(__instance, 0);
+        SyncBufferStepsField?.SetValue(__instance, false);
+    }
 
-        // Always keep shuttlecock blocked while GS-only (covers dashing frames before isSprinting).
-        hc.PreventShuttlecock();
-        NoShuttlecockTimeField?.SetValue(hc, Time.timeAsDouble + 1.0);
+    private static void LeftGroundPostfix(HeroController __instance)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+        CancelSprintHard(__instance, clampAirSpeed: true);
+    }
 
-        if (!hc.cState.onGround)
+    private static void HeroUpdatePostfix(HeroController __instance) => TickGuards(__instance, physics: false);
+    private static void HeroFixedUpdatePostfix(HeroController __instance) => TickGuards(__instance, physics: true);
+
+    private static void TickGuards(HeroController hc, bool physics)
+    {
+        if (!OnlyGroundedSprintKit())
         {
-            CancelSprintHard(hc);
+            _wasOnGround = hc.cState.onGround;
             return;
         }
 
-        // Hold-dash on ground: poke TRY SPRINT if idle walk (FSM may need the nudge).
+        hc.PreventShuttlecock();
+        NoShuttlecockTimeField?.SetValue(hc, Time.timeAsDouble + 1.0);
+
+        bool grounded = IsEffectivelyGrounded(hc);
+
+        // Edge: just left ground (ledge or jump) — cancel immediately.
+        if (_wasOnGround && !grounded)
+            CancelSprintHard(hc, clampAirSpeed: true);
+
+        _wasOnGround = grounded;
+
+        if (!grounded)
+        {
+            CancelSprintHard(hc, clampAirSpeed: true);
+            if (physics)
+                ClampAirHorizontalSpeed(hc);
+            return;
+        }
+
+        // Ground: hold dash → enter vanilla sprint path without enabling CanDash/HeroDash.
         if (InputHandler.Instance != null
             && InputHandler.Instance.inputActions.Dash.IsPressed
             && !hc.cState.dashing
-            && !hc.cState.isSprinting
-            && !hc.cState.isBackSprinting
+            && !hc.cState.hazardDeath
             && hc.CanSprint())
         {
             hc.sprintFSM?.SendEvent("TRY SPRINT");
         }
     }
 
-    private static void LeftGroundPostfix(HeroController __instance)
+    private static void CancelSprintHard(HeroController hc, bool clampAirSpeed)
     {
-        if (!OnlyGroundedSprintKit()) return;
-        CancelSprintHard(__instance);
+        SprintBufferStepsField?.SetValue(hc, 0);
+        SyncBufferStepsField?.SetValue(hc, false);
+
+        hc.sprintFSM?.SendEvent("CANCEL SPRINT");
+        // Extra cancel events some sprint substates listen for
+        hc.sprintFSM?.SendEvent("HARD LANDING");
+
+        hc.cState.isSprinting = false;
+        hc.cState.isBackSprinting = false;
+
+        if (hc.sprintFSM != null)
+        {
+            var isSprint = hc.sprintFSM.FsmVariables.GetFsmBool("Is Sprinting");
+            if (isSprint != null) isSprint.Value = false;
+        }
+
+        if (SprintSpeedAddFloatField?.GetValue(hc) is HutongGames.PlayMaker.FsmFloat add)
+            add.Value = 0f;
+
+        if (clampAirSpeed && !IsEffectivelyGrounded(hc))
+            ClampAirHorizontalSpeed(hc);
     }
 
     /// <summary>
-    /// Force end of sprint state for GS-only: FSM event + cState + buffer + Add Speed float.
+    /// Cap midair horizontal speed to walk so "still sprinting off a ledge" has no mobility gain.
     /// </summary>
-    private static void CancelSprintHard(HeroController hc)
+    private static void ClampAirHorizontalSpeed(HeroController hc)
     {
-        SprintBufferStepsField?.SetValue(hc, 0);
+        Rigidbody2D rb = hc.rb2d;
+        if (rb == null) return;
 
-        bool wasSprinting = hc.cState.isSprinting
-            || hc.cState.isBackSprinting
-            || hc.cState.isBackScuttling
-            || (hc.sprintFSM != null && hc.sprintFSM.FsmVariables.GetFsmBool("Is Sprinting") is { } b && b.Value);
+        float max = Mathf.Abs(hc.GetWalkSpeed());
+        if (max < 0.01f) max = 6f; // fallback if walk speed unreadable
 
-        if (wasSprinting || !hc.cState.onGround)
+        Vector2 v = rb.linearVelocity;
+        if (Mathf.Abs(v.x) > max)
         {
-            hc.sprintFSM?.SendEvent("CANCEL SPRINT");
-            // Direct cState clear if FSM is slow a frame
-            hc.cState.isSprinting = false;
-            hc.cState.isBackSprinting = false;
+            v.x = Mathf.Sign(v.x) * max;
+            rb.linearVelocity = v;
         }
-
-        // Zero sprint speed add so residual velocity doesn't linger mid-air
-        if (SprintSpeedAddFloatField?.GetValue(hc) is HutongGames.PlayMaker.FsmFloat add)
-            add.Value = 0f;
     }
 }

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -11,10 +11,10 @@ namespace ItemChanger.Silksong.Modules.CustomSkills;
 /// flibber (#209): trick the game so vanilla sprint anim/cState run.
 ///
 /// Playtest fixes:
-/// - Ledge fall kept sprinting: CANCEL SPRINT alone is not enough; clamp air horizontal
-///   speed to walk and zero FSM Add Speed every physics tick while airborne.
-/// - Wall clip on turn+jump: do NOT spoof CanDash (that starts a real ground dash into
-///   walls). Enter sprint only via TRY SPRINT + GetBool("hasDash") while grounded.
+/// - Ledge fall: hard cancel + clamp air horizontal speed to walk.
+/// - Wall clip: never allow real HeroDash for GS-only.
+/// - Ground dash still worked: Prepatcher makes playerData.hasDash use GetBool, so
+///   spoofing hasDash made CanDash true. Force CanDash false and block HeroDash*.
 /// </summary>
 public class GroundedSprintModule : CustomSkillModule
 {
@@ -121,8 +121,22 @@ public class GroundedSprintModule : CustomSkillModule
 
         _harmony = new Harmony("itemchanger.silksong.groundedsprint");
 
-        // Intentionally NOT spoofing CanDash — that starts a real ground dash and caused
-        // wall clips on turn+jump. Sprint entry is TRY SPRINT + GetBool hasDash only.
+        // GetBool("hasDash") is true while grounded so the sprint FSM can run, but
+        // Prepatcher routes playerData.hasDash through GetBool — so CanDash would also
+        // become true. Force CanDash false and block HeroDash* for GS-only (sprint only).
+        Patch(typeof(HeroController), nameof(HeroController.CanDash), postfix: nameof(CanDashPostfix));
+        var heroDashPressed = AccessTools.Method(typeof(HeroController), "HeroDashPressed");
+        if (heroDashPressed != null)
+        {
+            _harmony.Patch(heroDashPressed,
+                prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroDashPressedPrefix)));
+        }
+        var heroDash = AccessTools.Method(typeof(HeroController), "HeroDash", [typeof(bool)]);
+        if (heroDash != null)
+        {
+            _harmony.Patch(heroDash,
+                prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroDashPrefix)));
+        }
 
         Patch(typeof(HeroController), "Update", postfix: nameof(HeroUpdatePostfix));
         Patch(typeof(HeroController), "FixedUpdate", postfix: nameof(HeroFixedUpdatePostfix));
@@ -150,7 +164,7 @@ public class GroundedSprintModule : CustomSkillModule
         }
 
         ItemChangerPlugin.Instance.Logger.LogInfo(
-            "[GroundedSprint] loaded: GetBool grounded hasDash, TRY SPRINT only (no CanDash), hard air clamp.");
+            "[GroundedSprint] loaded: GetBool hasDash for FSM, CanDash/HeroDash blocked, TRY SPRINT + air clamp.");
     }
 
     private void Patch(Type type, string name, string? prefix = null, string? postfix = null)
@@ -188,6 +202,35 @@ public class GroundedSprintModule : CustomSkillModule
     }
 
     // ---- Harmony ----
+
+    /// <summary>
+    /// Prepatcher makes hasDash property use GetBool — force dash ability off for GS-only.
+    /// Sprint is entered via TRY SPRINT, not HeroDash.
+    /// </summary>
+    private static void CanDashPostfix(HeroController __instance, ref bool __result)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+        __result = false;
+    }
+
+    /// <summary>Skip HeroDashPressed entirely for GS-only (redirect dash button to sprint).</summary>
+    private static bool HeroDashPressedPrefix(HeroController __instance)
+    {
+        if (!OnlyGroundedSprintKit()) return true;
+        // Convert dash press into sprint attempt on ground only.
+        if (__instance.cState.onGround && __instance.CanSprint())
+            __instance.sprintFSM?.SendEvent("TRY SPRINT");
+        return false; // skip original dash
+    }
+
+    private static bool HeroDashPrefix(HeroController __instance, bool startAlreadyDashing)
+    {
+        if (!OnlyGroundedSprintKit()) return true;
+        // Never start a real dash with GS-only.
+        if (__instance.cState.onGround && __instance.CanSprint())
+            __instance.sprintFSM?.SendEvent("TRY SPRINT");
+        return false;
+    }
 
     private static bool OnShuttleCockJumpPrefix() => !OnlyGroundedSprintKit();
 

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -1,44 +1,59 @@
 using HarmonyLib;
-using ItemChanger.Silksong.Extensions;
-using ItemChanger.Silksong.RawData;
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
+using ItemChanger.Silksong.FsmStateActions;
+using Silksong.FsmUtil;
 using System.Reflection;
 
 namespace ItemChanger.Silksong.Modules.CustomSkills;
 
 /// <summary>
-/// Novelty skill: sprint at Swift Step speed while grounded, without granting air sprint or dash.
-/// Implements flibber's "trick the game" approach via <see cref="CustomSkillPlayerDataModule"/>:
-/// <c>PlayerData.GetBool("hasDash")</c> returns true only when grounded + owned, so the vanilla
-/// sprint FSM (animations, cState, Sprintmaster/Quickening tiers) runs unchanged.
-/// Direct field reads of <c>playerData.hasDash</c> (e.g. <c>CanDash</c>) stay false until real Swift Step.
+/// Novelty: Swift Step sprint while grounded only — no air sprint, no dash for logic.
+///
+/// flibber (#209): trick the game so the vanilla sprint path runs (animations / cState),
+/// rather than faking speed in GetRunSpeed. We rewrite the sprintFSM's hasDash gate to
+/// <c>hasDash || (hasGroundedSprint &amp;&amp; onGround)</c> so the FSM owns speed tiers
+/// (Sprintmaster / Quickening) and anim. Direct field <c>playerData.hasDash</c> stays false
+/// until real Swift Step (CanDash, etc.).
+///
+/// FSM viewer: HeroController GameObject → component sprintFSM (PlayMakerFSM "Sprint") →
+/// states that contain PlayerDataBoolTest(boolName=hasDash). Known candidates listed in
+/// <see cref="KnownHasDashGateStates"/>; discovery pass logs any additional names once.
 /// </summary>
 public class GroundedSprintModule : CustomSkillModule
 {
-#pragma warning disable IDE1006 // Naming Styles — match PlayerData / skill bool convention
+#pragma warning disable IDE1006 // Naming Styles
     public bool hasGroundedSprint { get; set; }
 #pragma warning restore IDE1006
+
+    /// <summary>
+    /// Sprint FSM state names that gate on hasDash (PlayerDataBoolTest).
+    /// Prefer named lookup (flibber review) over scanning every state.
+    /// Confirmed/extended via one-time discovery log when empty hit.
+    /// </summary>
+    private static readonly string[] KnownHasDashGateStates =
+    [
+        "Sprint?",
+        "Can Sprint?",
+        "Has Dash?",
+        "Check Dash",
+        "Check Sprint",
+        "Try Sprint",
+        "TRY SPRINT",
+    ];
 
     private static GroundedSprintModule? _activeInstance;
     private static readonly FieldInfo? SprintBufferStepsField =
         AccessTools.Field(typeof(HeroController), "sprintBufferSteps");
-    private static readonly FieldInfo? HasDashField =
-        AccessTools.Field(typeof(PlayerData), "hasDash")
-        ?? AccessTools.DeclaredField(typeof(PlayerData), "hasDash");
 
     private Harmony? _harmony;
+    private bool _fsmPatched;
 
-    public override IEnumerable<string> GettableSkillBools() =>
-    [
-        nameof(hasGroundedSprint),
-        // Intercept GetBool("hasDash") for sprint FSM / PlayMaker tests only.
-        // Conflicts with SplitSwiftStep if both register hasDash — log error, last-loaded wins.
-        nameof(PlayerData.hasDash),
-    ];
+    public override IEnumerable<string> GettableSkillBools() => [nameof(hasGroundedSprint)];
 
     public override bool GetBool(string boolName) => boolName switch
     {
         nameof(hasGroundedSprint) => hasGroundedSprint,
-        nameof(PlayerData.hasDash) => ComputeEffectiveHasDash(),
         _ => throw UnsupportedBoolName(boolName),
     };
 
@@ -56,59 +71,24 @@ public class GroundedSprintModule : CustomSkillModule
         }
     }
 
-    /// <summary>
-    /// True if the player owns real Swift Step (field), or owns Grounded Sprint and is on the ground.
-    /// </summary>
-    private bool ComputeEffectiveHasDash()
-    {
-        if (ReadRawHasDash()) return true;
-        if (!hasGroundedSprint) return false;
-        HeroController? hc = HeroController.SilentInstance;
-        return hc != null && hc.cState.onGround;
-    }
-
-    /// <summary>Real Swift Step ownership via field — must not go through GetBool (recursion).</summary>
-    private static bool ReadRawHasDash()
-    {
-        PlayerData? pd = PlayerData.instance;
-        if (pd == null) return false;
-        if (HasDashField != null)
-            return (bool)HasDashField.GetValue(pd)!;
-        // Fallback: may recurse if hasDash is a GetBool-backed property; prefer field.
-        return false;
-    }
-
-    private static bool OnlyGroundedSprintKit()
-    {
-        GroundedSprintModule? module = _activeInstance;
-        if (module == null || !module.hasGroundedSprint) return false;
-        return !ReadRawHasDash();
-    }
-
     protected override void DoLoad()
     {
         base.DoLoad();
         _activeInstance = this;
+        _fsmPatched = false;
 
-        // Inventory "has Swift Step?" display should treat Grounded Sprint as owned sprint kit.
-        Using(Md.InventoryItemConditional.Evaluate.Prefix(OverrideInventoryDisplayTest));
+        // Patch sprintFSM once Hero is alive (sprintFSM assigned in HeroController.Start region).
+        Using(Md.HeroController.Start.Postfix(OnHeroStart));
 
-        // Per-frame air cancel, shuttlecock block, coyote-buffer clear.
-        // HeroController.Update may not have an Md hook; use Harmony.
         _harmony = new Harmony("itemchanger.silksong.groundedsprint");
+
         MethodInfo? update = AccessTools.Method(typeof(HeroController), "Update");
         if (update != null)
         {
             _harmony.Patch(update,
                 postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroUpdatePostfix)));
         }
-        else
-        {
-            ItemChangerPlugin.Instance.Logger.LogWarning(
-                "[GroundedSprint] HeroController.Update not found; air-cancel / shuttlecock guards inactive.");
-        }
 
-        // LeftGround refills sprintBufferSteps when leaving ground while sprinting (coyote sprint-jump).
         MethodInfo? leftGround = AccessTools.Method(typeof(HeroController), "LeftGround", [typeof(bool)]);
         if (leftGround != null)
         {
@@ -117,18 +97,16 @@ public class GroundedSprintModule : CustomSkillModule
         }
         else
         {
-            // Some builds may only have BecomeAirborne; still zero buffer in Update.
             MethodInfo? becomeAirborne = AccessTools.Method(typeof(HeroController), "BecomeAirborne");
             if (becomeAirborne != null)
             {
                 _harmony.Patch(becomeAirborne,
-                    postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(BecomeAirbornePostfix)));
+                    postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(LeftGroundPostfix)));
             }
         }
 
-        // HeroJump(bool checkSprint) — bool overload is what runs (no-arg is often inlined).
-        MethodInfo? heroJumpBool = AccessTools.Method(
-            typeof(HeroController), "HeroJump", [typeof(bool)]);
+        // Bool overload is the real body (no-arg often inlined).
+        MethodInfo? heroJumpBool = AccessTools.Method(typeof(HeroController), "HeroJump", [typeof(bool)]);
         if (heroJumpBool != null)
         {
             _harmony.Patch(heroJumpBool,
@@ -140,26 +118,117 @@ public class GroundedSprintModule : CustomSkillModule
     {
         _harmony?.UnpatchSelf();
         _harmony = null;
+        _fsmPatched = false;
         if (_activeInstance == this) _activeInstance = null;
         base.DoUnload();
     }
 
-    private void OverrideInventoryDisplayTest(InventoryItemConditional self)
+    private void OnHeroStart(HeroController self)
     {
-        // Only remap when Grounded Sprint is the sole sprint kit so we don't
-        // disturb vanilla / SplitSwiftStep inventory for real hasDash owners.
-        if (!hasGroundedSprint || ReadRawHasDash()) return;
-        if (self.Test.IsSingleTest(out PlayerDataTest.Test t) && t.FieldName == nameof(PlayerData.hasDash))
-        {
-            self.Test.Modify(test =>
-            {
-                test.FieldName = nameof(hasGroundedSprint);
-                return test;
-            });
-        }
+        TryPatchSprintFsm(self);
     }
 
-    // ---- Harmony targets ----
+    /// <summary>
+    /// Rewrite hasDash PlayerDataBoolTest actions on the sprint FSM so Grounded Sprint
+    /// can enter the vanilla sprint path while on the ground only.
+    /// </summary>
+    private void TryPatchSprintFsm(HeroController self)
+    {
+        if (_fsmPatched) return;
+        PlayMakerFSM? sprint = self.sprintFSM;
+        if (sprint == null || sprint.Fsm == null) return;
+
+        int rewrites = 0;
+        var patchedStateNames = new List<string>();
+
+        // 1) Named states first (maintainability — flibber #209).
+        foreach (string stateName in KnownHasDashGateStates)
+        {
+            FsmState? state = sprint.GetState(stateName);
+            if (state == null) continue;
+            int n = RewriteHasDashTests(state);
+            if (n > 0)
+            {
+                rewrites += n;
+                patchedStateNames.Add(stateName);
+            }
+        }
+
+        // 2) One-time discovery if known list missed (log names so we can hardcode later).
+        if (rewrites == 0 && sprint.FsmStates != null)
+        {
+            foreach (FsmState state in sprint.FsmStates)
+            {
+                if (state == null) continue;
+                int n = RewriteHasDashTests(state);
+                if (n > 0)
+                {
+                    rewrites += n;
+                    patchedStateNames.Add(state.Name);
+                }
+            }
+            if (rewrites > 0)
+            {
+                ItemChangerPlugin.Instance.Logger.LogInfo(
+                    $"[GroundedSprint] discovery: add these state names to KnownHasDashGateStates: {string.Join(", ", patchedStateNames)}");
+            }
+        }
+
+        if (rewrites == 0)
+        {
+            ItemChangerPlugin.Instance.Logger.LogWarning(
+                "[GroundedSprint] no PlayerDataBoolTest(hasDash) found on sprintFSM — sprint gate not rewritten.");
+            return;
+        }
+
+        _fsmPatched = true;
+        ItemChangerPlugin.Instance.Logger.LogInfo(
+            $"[GroundedSprint] sprintFSM hasDash gate rewritten ({rewrites} action(s) in states: {string.Join(", ", patchedStateNames)}).");
+    }
+
+    private static int RewriteHasDashTests(FsmState state)
+    {
+        int rewrites = 0;
+        state.ReplaceActionsOfType<PlayerDataBoolTest>(orig =>
+        {
+            if (orig.boolName?.Value != nameof(PlayerData.hasDash))
+                return orig;
+            rewrites++;
+            return new CustomCheckFsmStateAction(orig)
+            {
+                GetIsTrue = ShouldAllowSprint,
+            };
+        });
+        return rewrites;
+    }
+
+    /// <summary>
+    /// True when vanilla Swift Step is owned, or Grounded Sprint is owned and Hornet is on the ground.
+    /// </summary>
+    private static bool ShouldAllowSprint()
+    {
+        PlayerData? pd = PlayerData.instance;
+        if (pd != null && pd.hasDash)
+            return true;
+
+        GroundedSprintModule? module = _activeInstance;
+        if (module == null || !module.hasGroundedSprint)
+            return false;
+
+        HeroController? hc = HeroController.SilentInstance;
+        return hc != null && hc.cState.onGround;
+    }
+
+    private static bool OnlyGroundedSprintKit()
+    {
+        GroundedSprintModule? module = _activeInstance;
+        if (module == null || !module.hasGroundedSprint)
+            return false;
+        PlayerData? pd = PlayerData.instance;
+        return pd == null || !pd.hasDash;
+    }
+
+    // ---- Air / shuttle-cock guards (issue #52: no air logic benefit) ----
 
     private static void HeroUpdatePostfix(HeroController __instance)
     {
@@ -167,20 +236,14 @@ public class GroundedSprintModule : CustomSkillModule
 
         if (!__instance.cState.onGround)
         {
-            // Leave ground while "sprinting" under grounded kit → cancel vanilla sprint FSM.
             if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
-            {
                 __instance.sprintFSM?.SendEvent("CANCEL SPRINT");
-            }
             SprintBufferStepsField?.SetValue(__instance, 0);
             return;
         }
 
-        // Grounded and actively sprinting: block shuttle-cock sprint-jump.
         if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
-        {
             __instance.PreventShuttlecock();
-        }
     }
 
     private static void LeftGroundPostfix(HeroController __instance)
@@ -188,21 +251,12 @@ public class GroundedSprintModule : CustomSkillModule
         if (!OnlyGroundedSprintKit()) return;
         SprintBufferStepsField?.SetValue(__instance, 0);
         if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
-        {
             __instance.sprintFSM?.SendEvent("CANCEL SPRINT");
-        }
-    }
-
-    private static void BecomeAirbornePostfix(HeroController __instance)
-    {
-        // Fallback if LeftGround is missing.
-        LeftGroundPostfix(__instance);
     }
 
     private static void HeroJumpBoolPrefix(ref bool checkSprint)
     {
         if (!OnlyGroundedSprintKit()) return;
-        // Collapse sprint-jump gate: if (checkSprint && (buffer || dashing || isSprinting) && time)
         checkSprint = false;
     }
 }

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -1,59 +1,51 @@
 using HarmonyLib;
-using HutongGames.PlayMaker;
-using HutongGames.PlayMaker.Actions;
-using ItemChanger.Silksong.FsmStateActions;
-using Silksong.FsmUtil;
+using ItemChanger.Silksong.Extensions;
 using System.Reflection;
 
 namespace ItemChanger.Silksong.Modules.CustomSkills;
 
 /// <summary>
-/// Novelty: Swift Step sprint while grounded only — no air sprint, no dash for logic.
+/// Novelty: Swift Step sprint while grounded, without air dash / air sprint for logic.
 ///
-/// flibber (#209): trick the game so the vanilla sprint path runs (animations / cState),
-/// rather than faking speed in GetRunSpeed. We rewrite the sprintFSM's hasDash gate to
-/// <c>hasDash || (hasGroundedSprint &amp;&amp; onGround)</c> so the FSM owns speed tiers
-/// (Sprintmaster / Quickening) and anim. Direct field <c>playerData.hasDash</c> stays false
-/// until real Swift Step (CanDash, etc.).
+/// flibber (#209): trick the game into thinking the player has dash at the right times
+/// so vanilla animations and cState work — not a GetRunSpeed speed hack.
 ///
-/// FSM viewer: HeroController GameObject → component sprintFSM (PlayMakerFSM "Sprint") →
-/// states that contain PlayerDataBoolTest(boolName=hasDash). Known candidates listed in
-/// <see cref="KnownHasDashGateStates"/>; discovery pass logs any additional names once.
+/// Silksong path (decomp): Dash.WasPressed → CanDash() [field hasDash] → HeroDash →
+/// sprintFSM "DASHED" → FinishedDashing → "TRY SPRINT". Sprint speed is FSM "Add Speed",
+/// not GetRunSpeed. There is no PlayerDataBoolTest(hasDash) on sprintFSM.
+///
+/// We:
+/// 1) Spoof GetBool("hasDash") while grounded + owned (CustomSkillPlayerDataModule)
+/// 2) Postfix CanDash so ground dash→sprint can start (field hasDash stays false for air)
+/// 3) Cancel sprint / clear buffer / PreventShuttlecock in air
 /// </summary>
 public class GroundedSprintModule : CustomSkillModule
 {
-#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE1006
     public bool hasGroundedSprint { get; set; }
 #pragma warning restore IDE1006
-
-    /// <summary>
-    /// Sprint FSM state names that gate on hasDash (PlayerDataBoolTest).
-    /// Prefer named lookup (flibber review) over scanning every state.
-    /// Confirmed/extended via one-time discovery log when empty hit.
-    /// </summary>
-    private static readonly string[] KnownHasDashGateStates =
-    [
-        "Sprint?",
-        "Can Sprint?",
-        "Has Dash?",
-        "Check Dash",
-        "Check Sprint",
-        "Try Sprint",
-        "TRY SPRINT",
-    ];
 
     private static GroundedSprintModule? _activeInstance;
     private static readonly FieldInfo? SprintBufferStepsField =
         AccessTools.Field(typeof(HeroController), "sprintBufferSteps");
+    private static readonly FieldInfo? HasDashField =
+        AccessTools.Field(typeof(PlayerData), "hasDash")
+        ?? AccessTools.DeclaredField(typeof(PlayerData), "hasDash");
 
     private Harmony? _harmony;
-    private bool _fsmPatched;
 
-    public override IEnumerable<string> GettableSkillBools() => [nameof(hasGroundedSprint)];
+    public override IEnumerable<string> GettableSkillBools() =>
+    [
+        nameof(hasGroundedSprint),
+        // GetPlayerDataBool / PlayMaker path (and inventory tests via GetBool).
+        // Conflicts with SplitSwiftStep if both register hasDash — rare; log error on load.
+        nameof(PlayerData.hasDash),
+    ];
 
     public override bool GetBool(string boolName) => boolName switch
     {
         nameof(hasGroundedSprint) => hasGroundedSprint,
+        nameof(PlayerData.hasDash) => ComputeEffectiveHasDash(),
         _ => throw UnsupportedBoolName(boolName),
     };
 
@@ -71,16 +63,62 @@ public class GroundedSprintModule : CustomSkillModule
         }
     }
 
+    /// <summary>
+    /// True if real Swift Step (field) or Grounded Sprint while on the ground.
+    /// </summary>
+    private bool ComputeEffectiveHasDash()
+    {
+        if (ReadRawHasDash()) return true;
+        if (!hasGroundedSprint) return false;
+        HeroController? hc = HeroController.SilentInstance;
+        return hc != null && hc.cState.onGround;
+    }
+
+    /// <summary>True field ownership — never call GetBool (recursion).</summary>
+    private static bool ReadRawHasDash()
+    {
+        PlayerData? pd = PlayerData.instance;
+        if (pd == null) return false;
+        if (HasDashField != null)
+            return (bool)HasDashField.GetValue(pd)!;
+        return false;
+    }
+
+    private static bool OnlyGroundedSprintKit()
+    {
+        GroundedSprintModule? module = _activeInstance;
+        if (module == null || !module.hasGroundedSprint) return false;
+        return !ReadRawHasDash();
+    }
+
+    private static bool GroundedSprintActiveOnGround()
+    {
+        if (!OnlyGroundedSprintKit()) return false;
+        HeroController? hc = HeroController.SilentInstance;
+        return hc != null && hc.cState.onGround;
+    }
+
     protected override void DoLoad()
     {
         base.DoLoad();
         _activeInstance = this;
-        _fsmPatched = false;
 
-        // Patch sprintFSM once Hero is alive (sprintFSM assigned in HeroController.Start region).
-        Using(Md.HeroController.Start.Postfix(OnHeroStart));
+        // Inventory: show sprint-related entries when GS owned (stable, not ground-gated).
+        Using(Md.InventoryItemConditional.Evaluate.Prefix(OverrideInventoryDisplayTest));
 
         _harmony = new Harmony("itemchanger.silksong.groundedsprint");
+
+        // CanDash uses field hasDash — must postfix so ground dash→sprint can start.
+        MethodInfo? canDash = AccessTools.Method(typeof(HeroController), nameof(HeroController.CanDash));
+        if (canDash != null)
+        {
+            _harmony.Patch(canDash,
+                postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(CanDashPostfix)));
+        }
+        else
+        {
+            ItemChangerPlugin.Instance.Logger.LogWarning("[GroundedSprint] CanDash not found.");
+        }
 
         MethodInfo? update = AccessTools.Method(typeof(HeroController), "Update");
         if (update != null)
@@ -105,130 +143,53 @@ public class GroundedSprintModule : CustomSkillModule
             }
         }
 
-        // Bool overload is the real body (no-arg often inlined).
         MethodInfo? heroJumpBool = AccessTools.Method(typeof(HeroController), "HeroJump", [typeof(bool)]);
         if (heroJumpBool != null)
         {
             _harmony.Patch(heroJumpBool,
                 prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroJumpBoolPrefix)));
         }
+
+        ItemChangerPlugin.Instance.Logger.LogInfo(
+            "[GroundedSprint] loaded: CanDash/GetBool grounded spoof + air cancel guards.");
     }
 
     protected override void DoUnload()
     {
         _harmony?.UnpatchSelf();
         _harmony = null;
-        _fsmPatched = false;
         if (_activeInstance == this) _activeInstance = null;
         base.DoUnload();
     }
 
-    private void OnHeroStart(HeroController self)
+    private void OverrideInventoryDisplayTest(InventoryItemConditional self)
     {
-        TryPatchSprintFsm(self);
+        if (!hasGroundedSprint || ReadRawHasDash()) return;
+        if (self.Test.IsSingleTest(out PlayerDataTest.Test t) && t.FieldName == nameof(PlayerData.hasDash))
+        {
+            self.Test.Modify(test =>
+            {
+                test.FieldName = nameof(hasGroundedSprint);
+                return test;
+            });
+        }
     }
+
+    // ---- Harmony ----
 
     /// <summary>
-    /// Rewrite hasDash PlayerDataBoolTest actions on the sprint FSM so Grounded Sprint
-    /// can enter the vanilla sprint path while on the ground only.
+    /// Field hasDash is false for GS-only. Allow CanDash on ground so HeroDash → DASHED → sprint runs.
+    /// Air stays false → no air dash.
     /// </summary>
-    private void TryPatchSprintFsm(HeroController self)
+    private static void CanDashPostfix(HeroController __instance, ref bool __result)
     {
-        if (_fsmPatched) return;
-        PlayMakerFSM? sprint = self.sprintFSM;
-        if (sprint == null || sprint.Fsm == null) return;
-
-        int rewrites = 0;
-        var patchedStateNames = new List<string>();
-
-        // 1) Named states first (maintainability — flibber #209).
-        foreach (string stateName in KnownHasDashGateStates)
-        {
-            FsmState? state = sprint.GetState(stateName);
-            if (state == null) continue;
-            int n = RewriteHasDashTests(state);
-            if (n > 0)
-            {
-                rewrites += n;
-                patchedStateNames.Add(stateName);
-            }
-        }
-
-        // 2) One-time discovery if known list missed (log names so we can hardcode later).
-        if (rewrites == 0 && sprint.FsmStates != null)
-        {
-            foreach (FsmState state in sprint.FsmStates)
-            {
-                if (state == null) continue;
-                int n = RewriteHasDashTests(state);
-                if (n > 0)
-                {
-                    rewrites += n;
-                    patchedStateNames.Add(state.Name);
-                }
-            }
-            if (rewrites > 0)
-            {
-                ItemChangerPlugin.Instance.Logger.LogInfo(
-                    $"[GroundedSprint] discovery: add these state names to KnownHasDashGateStates: {string.Join(", ", patchedStateNames)}");
-            }
-        }
-
-        if (rewrites == 0)
-        {
-            ItemChangerPlugin.Instance.Logger.LogWarning(
-                "[GroundedSprint] no PlayerDataBoolTest(hasDash) found on sprintFSM — sprint gate not rewritten.");
-            return;
-        }
-
-        _fsmPatched = true;
-        ItemChangerPlugin.Instance.Logger.LogInfo(
-            $"[GroundedSprint] sprintFSM hasDash gate rewritten ({rewrites} action(s) in states: {string.Join(", ", patchedStateNames)}).");
+        if (__result) return;
+        if (!OnlyGroundedSprintKit()) return;
+        if (!__instance.cState.onGround) return;
+        // Match other CanDash gates loosely: no hazard death, allow input path.
+        if (__instance.cState.hazardDeath) return;
+        __result = true;
     }
-
-    private static int RewriteHasDashTests(FsmState state)
-    {
-        int rewrites = 0;
-        state.ReplaceActionsOfType<PlayerDataBoolTest>(orig =>
-        {
-            if (orig.boolName?.Value != nameof(PlayerData.hasDash))
-                return orig;
-            rewrites++;
-            return new CustomCheckFsmStateAction(orig)
-            {
-                GetIsTrue = ShouldAllowSprint,
-            };
-        });
-        return rewrites;
-    }
-
-    /// <summary>
-    /// True when vanilla Swift Step is owned, or Grounded Sprint is owned and Hornet is on the ground.
-    /// </summary>
-    private static bool ShouldAllowSprint()
-    {
-        PlayerData? pd = PlayerData.instance;
-        if (pd != null && pd.hasDash)
-            return true;
-
-        GroundedSprintModule? module = _activeInstance;
-        if (module == null || !module.hasGroundedSprint)
-            return false;
-
-        HeroController? hc = HeroController.SilentInstance;
-        return hc != null && hc.cState.onGround;
-    }
-
-    private static bool OnlyGroundedSprintKit()
-    {
-        GroundedSprintModule? module = _activeInstance;
-        if (module == null || !module.hasGroundedSprint)
-            return false;
-        PlayerData? pd = PlayerData.instance;
-        return pd == null || !pd.hasDash;
-    }
-
-    // ---- Air / shuttle-cock guards (issue #52: no air logic benefit) ----
 
     private static void HeroUpdatePostfix(HeroController __instance)
     {
@@ -240,6 +201,17 @@ public class GroundedSprintModule : CustomSkillModule
                 __instance.sprintFSM?.SendEvent("CANCEL SPRINT");
             SprintBufferStepsField?.SetValue(__instance, 0);
             return;
+        }
+
+        // Also poke TRY SPRINT while holding dash on ground if not already sprinting/dashing,
+        // so hold-to-sprint works even when a full dash burst is interrupted.
+        if (InputHandler.Instance != null
+            && InputHandler.Instance.inputActions.Dash.IsPressed
+            && !__instance.cState.dashing
+            && !__instance.cState.isSprinting
+            && __instance.CanSprint())
+        {
+            __instance.sprintFSM?.SendEvent("TRY SPRINT");
         }
 
         if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -10,14 +10,12 @@ namespace ItemChanger.Silksong.Modules.CustomSkills;
 ///
 /// flibber (#209): trick the game so vanilla sprint anim/cState run.
 ///
-/// Playtest fixes:
-/// - Ledge fall: soft cancel + clamp air horizontal speed to walk.
-/// - Wall clip: never allow real HeroDash for GS-only.
-/// - Ground dash still worked: Prepatcher makes playerData.hasDash use GetBool, so
-///   spoofing hasDash made CanDash true. Force CanDash false and block HeroDash*.
-/// - Jump-from-sprint / downslash: never send HARD LANDING (kills jump Y and interrupts
-///   air attacks). Only CANCEL SPRINT + flag clear, and only on leave-ground / jump —
-///   not every airborne frame.
+/// Critical decomp (HeroController.FixedUpdate):
+///   if (cState.jumping &amp;&amp; !cState.dashing &amp;&amp; !cState.isSprinting) Jump();
+/// Jump() is the only place that applies JUMP_SPEED. If isSprinting stays true after a
+/// sprint-jump (GS cancels shuttlecock but not the sprint flag in time), you get a
+/// near-zero hop. CanJump() also requires !isSprinting, so sprint jump normally goes
+/// through the shuttlecock FSM path — which we intentionally block.
 /// </summary>
 public class GroundedSprintModule : CustomSkillModule
 {
@@ -101,7 +99,6 @@ public class GroundedSprintModule : CustomSkillModule
     private static bool IsEffectivelyGrounded(HeroController hc)
     {
         if (hc.cState.onGround) return true;
-        // Don't treat wall-slide as ground sprint surface
         if (hc.cState.wallSliding || hc.cState.wallClinging || hc.cState.wallScrambling)
             return false;
         try
@@ -124,10 +121,9 @@ public class GroundedSprintModule : CustomSkillModule
 
         _harmony = new Harmony("itemchanger.silksong.groundedsprint");
 
-        // GetBool("hasDash") is true while grounded so the sprint FSM can run, but
-        // Prepatcher routes playerData.hasDash through GetBool — so CanDash would also
-        // become true. Force CanDash false and block HeroDash* for GS-only (sprint only).
         Patch(typeof(HeroController), nameof(HeroController.CanDash), postfix: nameof(CanDashPostfix));
+        Patch(typeof(HeroController), nameof(HeroController.CanJump), postfix: nameof(CanJumpPostfix));
+
         var heroDashPressed = AccessTools.Method(typeof(HeroController), "HeroDashPressed");
         if (heroDashPressed != null)
         {
@@ -141,8 +137,13 @@ public class GroundedSprintModule : CustomSkillModule
                 prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroDashPrefix)));
         }
 
-        Patch(typeof(HeroController), "Update", postfix: nameof(HeroUpdatePostfix));
-        Patch(typeof(HeroController), "FixedUpdate", postfix: nameof(HeroFixedUpdatePostfix));
+        // PREFIX FixedUpdate so isSprinting is cleared before Jump() gate.
+        Patch(typeof(HeroController), "Update",
+            prefix: nameof(HeroUpdatePrefix),
+            postfix: nameof(HeroUpdatePostfix));
+        Patch(typeof(HeroController), "FixedUpdate",
+            prefix: nameof(HeroFixedUpdatePrefix),
+            postfix: nameof(HeroFixedUpdatePostfix));
 
         var leftGround = AccessTools.Method(typeof(HeroController), "LeftGround", [typeof(bool)]);
         if (leftGround != null)
@@ -167,7 +168,7 @@ public class GroundedSprintModule : CustomSkillModule
         }
 
         ItemChangerPlugin.Instance.Logger.LogInfo(
-            "[GroundedSprint] loaded: GetBool hasDash for FSM, CanDash/HeroDash blocked, TRY SPRINT + air clamp.");
+            "[GroundedSprint] loaded: Jump-gate isSprinting clear (FixedUpdate prefix), CanJump while GS sprint, no shuttlecock.");
     }
 
     private void Patch(Type type, string name, string? prefix = null, string? postfix = null)
@@ -206,31 +207,44 @@ public class GroundedSprintModule : CustomSkillModule
 
     // ---- Harmony ----
 
-    /// <summary>
-    /// Prepatcher makes hasDash property use GetBool — force dash ability off for GS-only.
-    /// Sprint is entered via TRY SPRINT, not HeroDash.
-    /// </summary>
     private static void CanDashPostfix(HeroController __instance, ref bool __result)
     {
         if (!OnlyGroundedSprintKit()) return;
         __result = false;
     }
 
-    /// <summary>Skip HeroDashPressed entirely for GS-only (redirect dash button to sprint).</summary>
+    /// <summary>
+    /// Vanilla CanJump requires !isSprinting (sprint jump is shuttlecock via FSM).
+    /// GS blocks shuttlecock, so allow a normal grounded jump while GS-sprinting.
+    /// </summary>
+    private static void CanJumpPostfix(HeroController __instance, ref bool __result)
+    {
+        if (__result || !OnlyGroundedSprintKit()) return;
+        if (!__instance.cState.isSprinting && !__instance.cState.isBackSprinting) return;
+        // Mirror CanJump's safe grounded branch without ActorStates (not public in all refs).
+        if (__instance.cState.onGround
+            && !__instance.cState.dashing
+            && !__instance.cState.jumping
+            && !__instance.cState.hazardDeath
+            && !__instance.cState.hazardRespawning
+            && !__instance.cState.dead)
+        {
+            __result = true;
+        }
+    }
+
     private static bool HeroDashPressedPrefix(HeroController __instance)
     {
         if (!OnlyGroundedSprintKit()) return true;
-        // Convert dash press into sprint attempt on ground only.
-        if (__instance.cState.onGround && __instance.CanSprint())
+        if (__instance.cState.onGround && !__instance.cState.jumping && __instance.CanSprint())
             __instance.sprintFSM?.SendEvent("TRY SPRINT");
-        return false; // skip original dash
+        return false;
     }
 
     private static bool HeroDashPrefix(HeroController __instance, bool startAlreadyDashing)
     {
         if (!OnlyGroundedSprintKit()) return true;
-        // Never start a real dash with GS-only.
-        if (__instance.cState.onGround && __instance.CanSprint())
+        if (__instance.cState.onGround && !__instance.cState.jumping && __instance.CanSprint())
             __instance.sprintFSM?.SendEvent("TRY SPRINT");
         return false;
     }
@@ -240,21 +254,19 @@ public class GroundedSprintModule : CustomSkillModule
     private static void HeroJumpBoolPrefix(HeroController __instance, ref bool checkSprint)
     {
         if (!OnlyGroundedSprintKit()) return;
-        // Disable shuttlecock path without wrecking jump velocity.
         checkSprint = false;
         __instance.PreventShuttlecock();
         SprintBufferStepsField?.SetValue(__instance, 0);
         SyncBufferStepsField?.SetValue(__instance, false);
         NoShuttlecockTimeField?.SetValue(__instance, Time.timeAsDouble + 5.0);
-        // Soft cancel only — HARD LANDING / air clamp here was killing jump height.
+        // Must clear isSprinting here so Jump() can apply JUMP_SPEED this physics step.
         SoftCancelSprint(__instance, sendFsmEvent: true, clampAirSpeed: false);
+        __instance.cState.shuttleCock = false;
     }
 
-    /// <summary>Before LeftGround fills sprintBufferSteps from isSprinting/dashing.</summary>
     private static void LeftGroundPrefix(HeroController __instance)
     {
         if (!OnlyGroundedSprintKit()) return;
-        // Clear sprint flags BEFORE vanilla buffer fill (uses isSprinting || dashing).
         __instance.cState.isSprinting = false;
         __instance.cState.isBackSprinting = false;
         SprintBufferStepsField?.SetValue(__instance, 0);
@@ -267,7 +279,65 @@ public class GroundedSprintModule : CustomSkillModule
         SoftCancelSprint(__instance, sendFsmEvent: true, clampAirSpeed: true);
     }
 
+    /// <summary>
+    /// Before Update input: if jump pressed while GS-sprinting, cancel sprint so
+    /// CanJump/HeroJump see a clean non-sprint state.
+    /// </summary>
+    private static void HeroUpdatePrefix(HeroController __instance)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+
+        InputHandler? ih = InputHandler.Instance;
+        if (ih != null
+            && ih.inputActions.Jump.WasPressed
+            && (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
+            && __instance.cState.onGround)
+        {
+            SoftCancelSprint(__instance, sendFsmEvent: true, clampAirSpeed: false);
+            __instance.cState.shuttleCock = false;
+            __instance.PreventShuttlecock();
+        }
+    }
+
     private static void HeroUpdatePostfix(HeroController __instance) => TickGuards(__instance, physics: false);
+
+    /// <summary>
+    /// BEFORE FixedUpdate body: Jump() is gated on !isSprinting. Clear sprint flags
+    /// for any airborne / jumping frame so JUMP_SPEED applies and downspike isn't
+    /// fighting sprint control.
+    /// </summary>
+    private static void HeroFixedUpdatePrefix(HeroController __instance)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+
+        bool airborne = !IsEffectivelyGrounded(__instance)
+            || __instance.cState.jumping
+            || __instance.cState.doubleJumping
+            || __instance.cState.downSpiking
+            || __instance.cState.downSpikeAntic
+            || __instance.cState.shuttleCock;
+
+        if (!airborne) return;
+
+        // Hard-clear every physics frame while air/jumping — FSM can re-set isSprinting.
+        __instance.cState.isSprinting = false;
+        __instance.cState.isBackSprinting = false;
+        __instance.cState.shuttleCock = false;
+        SprintBufferStepsField?.SetValue(__instance, 0);
+        SyncBufferStepsField?.SetValue(__instance, false);
+        ClearSprintSpeedAdd(__instance);
+
+        if (__instance.sprintFSM != null)
+        {
+            var isSprint = __instance.sprintFSM.FsmVariables.GetFsmBool("Is Sprinting");
+            if (isSprint != null && isSprint.Value)
+            {
+                isSprint.Value = false;
+                __instance.sprintFSM.SendEvent("CANCEL SPRINT");
+            }
+        }
+    }
+
     private static void HeroFixedUpdatePostfix(HeroController __instance) => TickGuards(__instance, physics: true);
 
     private static void TickGuards(HeroController hc, bool physics)
@@ -282,31 +352,35 @@ public class GroundedSprintModule : CustomSkillModule
         NoShuttlecockTimeField?.SetValue(hc, Time.timeAsDouble + 1.0);
 
         bool grounded = IsEffectivelyGrounded(hc);
+        bool busyAirAction = hc.cState.jumping
+            || hc.cState.doubleJumping
+            || hc.cState.downSpiking
+            || hc.cState.downSpikeAntic
+            || hc.cState.attacking;
 
-        // Edge: just left ground (ledge or jump) — one soft cancel, not HARD LANDING.
         if (_wasOnGround && !grounded)
             SoftCancelSprint(hc, sendFsmEvent: true, clampAirSpeed: true);
 
         _wasOnGround = grounded;
 
-        if (!grounded)
+        if (!grounded || busyAirAction)
         {
-            // Maintain no-sprint midair without re-firing FSM events every frame
-            // (HARD LANDING spam broke jump height + downslash).
             if (hc.cState.isSprinting || hc.cState.isBackSprinting)
-                SoftCancelSprint(hc, sendFsmEvent: true, clampAirSpeed: true);
+                SoftCancelSprint(hc, sendFsmEvent: true, clampAirSpeed: !busyAirAction);
             else
                 ClearSprintSpeedAdd(hc);
 
-            if (physics)
+            // Don't clamp horizontal during downspike thrust (sets intentional X vel).
+            if (physics && !grounded && !hc.cState.downSpiking && !hc.cState.downSpikeAntic)
                 ClampAirHorizontalSpeed(hc);
             return;
         }
 
-        // Ground: hold dash → enter vanilla sprint path without enabling CanDash/HeroDash.
+        // Ground only: hold dash → sprint. Never while jumping.
         if (InputHandler.Instance != null
             && InputHandler.Instance.inputActions.Dash.IsPressed
             && !hc.cState.dashing
+            && !hc.cState.jumping
             && !hc.cState.hazardDeath
             && hc.CanSprint())
         {
@@ -314,10 +388,6 @@ public class GroundedSprintModule : CustomSkillModule
         }
     }
 
-    /// <summary>
-    /// End sprint cleanly. Never send HARD LANDING — that event aborts jump impulse
-    /// and interrupts aerial attacks (downslash).
-    /// </summary>
     private static void SoftCancelSprint(HeroController hc, bool sendFsmEvent, bool clampAirSpeed)
     {
         SprintBufferStepsField?.SetValue(hc, 0);
@@ -328,6 +398,7 @@ public class GroundedSprintModule : CustomSkillModule
 
         hc.cState.isSprinting = false;
         hc.cState.isBackSprinting = false;
+        hc.cState.shuttleCock = false;
 
         if (hc.sprintFSM != null)
         {
@@ -337,7 +408,7 @@ public class GroundedSprintModule : CustomSkillModule
 
         ClearSprintSpeedAdd(hc);
 
-        if (clampAirSpeed && !IsEffectivelyGrounded(hc))
+        if (clampAirSpeed && !IsEffectivelyGrounded(hc) && !hc.cState.downSpiking && !hc.cState.downSpikeAntic)
             ClampAirHorizontalSpeed(hc);
     }
 
@@ -347,16 +418,13 @@ public class GroundedSprintModule : CustomSkillModule
             add.Value = 0f;
     }
 
-    /// <summary>
-    /// Cap midair horizontal speed to walk so "still sprinting off a ledge" has no mobility gain.
-    /// </summary>
     private static void ClampAirHorizontalSpeed(HeroController hc)
     {
         Rigidbody2D rb = hc.rb2d;
         if (rb == null) return;
 
         float max = Mathf.Abs(hc.GetWalkSpeed());
-        if (max < 0.01f) max = 6f; // fallback if walk speed unreadable
+        if (max < 0.01f) max = 6f;
 
         Vector2 v = rb.linearVelocity;
         if (Mathf.Abs(v.x) > max)

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -418,13 +418,18 @@ public class GroundedSprintModule : CustomSkillModule
             add.Value = 0f;
     }
 
+    /// <summary>
+    /// Cap midair |vx| to run speed (not walk). Vanilla Move() uses GetRunSpeed() in air
+    /// (~8.25); walk (~5) was killing normal jump/fall air control. Sprint is faster than
+    /// run, so this still strips ledge-sprint carry without nerfing ordinary air mobility.
+    /// </summary>
     private static void ClampAirHorizontalSpeed(HeroController hc)
     {
         Rigidbody2D rb = hc.rb2d;
         if (rb == null) return;
 
-        float max = Mathf.Abs(hc.GetWalkSpeed());
-        if (max < 0.01f) max = 6f;
+        float max = Mathf.Abs(hc.GetRunSpeed());
+        if (max < 0.01f) max = 8.25f;
 
         Vector2 v = rb.linearVelocity;
         if (Mathf.Abs(v.x) > max)

--- a/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
+++ b/ItemChanger.Silksong/Modules/CustomSkills/GroundedSprintModule.cs
@@ -1,0 +1,208 @@
+using HarmonyLib;
+using ItemChanger.Silksong.Extensions;
+using ItemChanger.Silksong.RawData;
+using System.Reflection;
+
+namespace ItemChanger.Silksong.Modules.CustomSkills;
+
+/// <summary>
+/// Novelty skill: sprint at Swift Step speed while grounded, without granting air sprint or dash.
+/// Implements flibber's "trick the game" approach via <see cref="CustomSkillPlayerDataModule"/>:
+/// <c>PlayerData.GetBool("hasDash")</c> returns true only when grounded + owned, so the vanilla
+/// sprint FSM (animations, cState, Sprintmaster/Quickening tiers) runs unchanged.
+/// Direct field reads of <c>playerData.hasDash</c> (e.g. <c>CanDash</c>) stay false until real Swift Step.
+/// </summary>
+public class GroundedSprintModule : CustomSkillModule
+{
+#pragma warning disable IDE1006 // Naming Styles — match PlayerData / skill bool convention
+    public bool hasGroundedSprint { get; set; }
+#pragma warning restore IDE1006
+
+    private static GroundedSprintModule? _activeInstance;
+    private static readonly FieldInfo? SprintBufferStepsField =
+        AccessTools.Field(typeof(HeroController), "sprintBufferSteps");
+    private static readonly FieldInfo? HasDashField =
+        AccessTools.Field(typeof(PlayerData), "hasDash")
+        ?? AccessTools.DeclaredField(typeof(PlayerData), "hasDash");
+
+    private Harmony? _harmony;
+
+    public override IEnumerable<string> GettableSkillBools() =>
+    [
+        nameof(hasGroundedSprint),
+        // Intercept GetBool("hasDash") for sprint FSM / PlayMaker tests only.
+        // Conflicts with SplitSwiftStep if both register hasDash — log error, last-loaded wins.
+        nameof(PlayerData.hasDash),
+    ];
+
+    public override bool GetBool(string boolName) => boolName switch
+    {
+        nameof(hasGroundedSprint) => hasGroundedSprint,
+        nameof(PlayerData.hasDash) => ComputeEffectiveHasDash(),
+        _ => throw UnsupportedBoolName(boolName),
+    };
+
+    public override IEnumerable<string> SettableSkillBools() => [nameof(hasGroundedSprint)];
+
+    public override void SetBool(string boolName, bool value)
+    {
+        switch (boolName)
+        {
+            case nameof(hasGroundedSprint):
+                hasGroundedSprint = value;
+                break;
+            default:
+                throw UnsupportedBoolName(boolName);
+        }
+    }
+
+    /// <summary>
+    /// True if the player owns real Swift Step (field), or owns Grounded Sprint and is on the ground.
+    /// </summary>
+    private bool ComputeEffectiveHasDash()
+    {
+        if (ReadRawHasDash()) return true;
+        if (!hasGroundedSprint) return false;
+        HeroController? hc = HeroController.SilentInstance;
+        return hc != null && hc.cState.onGround;
+    }
+
+    /// <summary>Real Swift Step ownership via field — must not go through GetBool (recursion).</summary>
+    private static bool ReadRawHasDash()
+    {
+        PlayerData? pd = PlayerData.instance;
+        if (pd == null) return false;
+        if (HasDashField != null)
+            return (bool)HasDashField.GetValue(pd)!;
+        // Fallback: may recurse if hasDash is a GetBool-backed property; prefer field.
+        return false;
+    }
+
+    private static bool OnlyGroundedSprintKit()
+    {
+        GroundedSprintModule? module = _activeInstance;
+        if (module == null || !module.hasGroundedSprint) return false;
+        return !ReadRawHasDash();
+    }
+
+    protected override void DoLoad()
+    {
+        base.DoLoad();
+        _activeInstance = this;
+
+        // Inventory "has Swift Step?" display should treat Grounded Sprint as owned sprint kit.
+        Using(Md.InventoryItemConditional.Evaluate.Prefix(OverrideInventoryDisplayTest));
+
+        // Per-frame air cancel, shuttlecock block, coyote-buffer clear.
+        // HeroController.Update may not have an Md hook; use Harmony.
+        _harmony = new Harmony("itemchanger.silksong.groundedsprint");
+        MethodInfo? update = AccessTools.Method(typeof(HeroController), "Update");
+        if (update != null)
+        {
+            _harmony.Patch(update,
+                postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroUpdatePostfix)));
+        }
+        else
+        {
+            ItemChangerPlugin.Instance.Logger.LogWarning(
+                "[GroundedSprint] HeroController.Update not found; air-cancel / shuttlecock guards inactive.");
+        }
+
+        // LeftGround refills sprintBufferSteps when leaving ground while sprinting (coyote sprint-jump).
+        MethodInfo? leftGround = AccessTools.Method(typeof(HeroController), "LeftGround", [typeof(bool)]);
+        if (leftGround != null)
+        {
+            _harmony.Patch(leftGround,
+                postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(LeftGroundPostfix)));
+        }
+        else
+        {
+            // Some builds may only have BecomeAirborne; still zero buffer in Update.
+            MethodInfo? becomeAirborne = AccessTools.Method(typeof(HeroController), "BecomeAirborne");
+            if (becomeAirborne != null)
+            {
+                _harmony.Patch(becomeAirborne,
+                    postfix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(BecomeAirbornePostfix)));
+            }
+        }
+
+        // HeroJump(bool checkSprint) — bool overload is what runs (no-arg is often inlined).
+        MethodInfo? heroJumpBool = AccessTools.Method(
+            typeof(HeroController), "HeroJump", [typeof(bool)]);
+        if (heroJumpBool != null)
+        {
+            _harmony.Patch(heroJumpBool,
+                prefix: new HarmonyMethod(typeof(GroundedSprintModule), nameof(HeroJumpBoolPrefix)));
+        }
+    }
+
+    protected override void DoUnload()
+    {
+        _harmony?.UnpatchSelf();
+        _harmony = null;
+        if (_activeInstance == this) _activeInstance = null;
+        base.DoUnload();
+    }
+
+    private void OverrideInventoryDisplayTest(InventoryItemConditional self)
+    {
+        // Only remap when Grounded Sprint is the sole sprint kit so we don't
+        // disturb vanilla / SplitSwiftStep inventory for real hasDash owners.
+        if (!hasGroundedSprint || ReadRawHasDash()) return;
+        if (self.Test.IsSingleTest(out PlayerDataTest.Test t) && t.FieldName == nameof(PlayerData.hasDash))
+        {
+            self.Test.Modify(test =>
+            {
+                test.FieldName = nameof(hasGroundedSprint);
+                return test;
+            });
+        }
+    }
+
+    // ---- Harmony targets ----
+
+    private static void HeroUpdatePostfix(HeroController __instance)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+
+        if (!__instance.cState.onGround)
+        {
+            // Leave ground while "sprinting" under grounded kit → cancel vanilla sprint FSM.
+            if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
+            {
+                __instance.sprintFSM?.SendEvent("CANCEL SPRINT");
+            }
+            SprintBufferStepsField?.SetValue(__instance, 0);
+            return;
+        }
+
+        // Grounded and actively sprinting: block shuttle-cock sprint-jump.
+        if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
+        {
+            __instance.PreventShuttlecock();
+        }
+    }
+
+    private static void LeftGroundPostfix(HeroController __instance)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+        SprintBufferStepsField?.SetValue(__instance, 0);
+        if (__instance.cState.isSprinting || __instance.cState.isBackSprinting)
+        {
+            __instance.sprintFSM?.SendEvent("CANCEL SPRINT");
+        }
+    }
+
+    private static void BecomeAirbornePostfix(HeroController __instance)
+    {
+        // Fallback if LeftGround is missing.
+        LeftGroundPostfix(__instance);
+    }
+
+    private static void HeroJumpBoolPrefix(ref bool checkSprint)
+    {
+        if (!OnlyGroundedSprintKit()) return;
+        // Collapse sprint-jump gate: if (checkSprint && (buffer || dashing || isSprinting) && time)
+        checkSprint = false;
+    }
+}

--- a/ItemChanger.Silksong/RawData/BaseItemList/Novelties.cs
+++ b/ItemChanger.Silksong/RawData/BaseItemList/Novelties.cs
@@ -238,6 +238,19 @@ internal partial class BaseItemList
         },
     };
 
+    public static Item Grounded_Sprint => new CustomSkillItem
+    {
+        Name = ItemNames.Grounded_Sprint,
+        BoolName = nameof(GroundedSprintModule.hasGroundedSprint),
+        ModuleTypeName = typeof(GroundedSprintModule).FullName,
+        UIDef = new MsgUIDef
+        {
+            Name = ItemChangerLanguageStrings.INV_NAME_GROUNDED_SPRINT(),
+            ShopDesc = ItemChangerLanguageStrings.INV_DESC_GROUNDED_SPRINT(),
+            Sprite = null!,
+        },
+    };
+
     // combined shards and fragments
     //TODO: find fitting sprites
     public static Item Double_Mask_Shard => new MaskShardItem

--- a/ItemChanger.Silksong/RawData/ItemNames.cs
+++ b/ItemChanger.Silksong/RawData/ItemNames.cs
@@ -422,6 +422,7 @@ public static class ItemNames
     public const string Upslash = "Upslash";
     public const string Downslash = "Downslash";
     public const string Taunt = "Taunt";
+    public const string Grounded_Sprint = "Grounded_Sprint";
     public const string Double_Mask_Shard = "Double_Mask_Shard";
     public const string Full_Mask = "Full_Mask";
     public const string Full_Spool = "Full_Spool";

--- a/ItemChanger.Silksong/Resources/Languages/default.json
+++ b/ItemChanger.Silksong/Resources/Languages/default.json
@@ -6,7 +6,6 @@
   "FMT_FAST_TRAVEL_PATTERN": "{TRAVEL_TYPE} - {STATION_NAME}",
   "FMT_MATERIUM_ENTRY_NAME": "{0} Entry",
   "FMT_JOURNAL_ENTRY_NAME": "{0} Entry",
-
   "INV_NAME_SKILL_HARPOON_LEFT": "Left Clawline",
   "INV_NAME_SKILL_HARPOON_RIGHT": "Right Clawline",
   "INV_DESC_SKILL_HARPOON_LEFT": "Advanced Weaver talent. Throw the Silk-strung needle to the left and charge towards it.",
@@ -29,7 +28,6 @@
   "INV_DESC_TAUNT": "Learn the power to skip Sister Splinter",
   "GET_TAUNT_1": "Goad enemies into attacking",
   "SHOP_DESC_ROSARIES": "We're having a firesale today, go ahead and collect your rebate.",
-
   "CREST_HUNTER_NAME": "Crest of Hunter",
   "CREST_HUNTER_V2_NAME": "Crest of Hunter Level 2",
   "CREST_HUNTER_V3_NAME": "Crest of Hunter Level 3",
@@ -41,15 +39,15 @@
   "CREST_WITCH_NAME": "Crest of Witch",
   "CREST_CURSED_NAME": "Crest of Cursed Witch",
   "CREST_CLOAKLESS_NAME": "Crest of Cloakless",
-
   "FREE": "Free",
   "OBTAINED": "Obtained",
   "PAID": "Paid",
   "COST_FOR": "for",
-
   "QUEST_BROLLY_GET_DESC_PREVIEW": "Hunt Hokers in the Far Fields and collect Spine Cores for {PREVIEW_TEXT}.",
   "SEAMSTRESS_BROLLY_QUEST_OFFER_PREVIEW": "If you’re planning to ascend from these low fields, you’ll be needing {PREVIEW_TEXT}, and I’m just the bug to help.<page>Head for the caves beyond my home. The bugs within produce a spine with a marvellous core, flexible yet strong.<page>Cut their spines and collect the cores. Return to me, and I’ll soon have your old cloak transformed into {PREVIEW_TEXT}.",
   "SEAMSTRESS_BROLLY_QUEST_REOFFER_PREVIEW": "Ready to reconsider my offer? Good for you! You won’t be going far without {PREVIEW_TEXT}, dear.",
   "SNAILS_ACT3_DESCEND_HINT": "Enough chatting, Old One. Return with the Needolin, and after visiting the lake of liquid nothing.",
-  "FMT_HUNTER_FAN_COMPLETION_RESULT": "Oooh, but the scroll is so heavy with {COUNTER} beautiful beasts! Miss grown-up, you must prey on {TARGET} beasts for your reward. No time for rest!"
+  "FMT_HUNTER_FAN_COMPLETION_RESULT": "Oooh, but the scroll is so heavy with {COUNTER} beautiful beasts! Miss grown-up, you must prey on {TARGET} beasts for your reward. No time for rest!",
+  "INV_NAME_GROUNDED_SPRINT": "Grounded Sprint",
+  "INV_DESC_GROUNDED_SPRINT": "Hold dash to sprint at Swift Step's pace while grounded. Cancels in the air."
 }

--- a/ItemChangerTesting/ModuleTests/GroundedSprintPhysicsProbe.cs
+++ b/ItemChangerTesting/ModuleTests/GroundedSprintPhysicsProbe.cs
@@ -1,0 +1,177 @@
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+using ItemChanger;
+using ItemChanger.Silksong.Modules.CustomSkills;
+using UnityEngine;
+
+namespace ItemChangerTesting.ModuleTests;
+
+/// <summary>
+/// In-engine physics probe for Grounded Sprint. Samples real HeroController rb2d
+/// velocity across jump / sprint-jump scenarios and writes a report under
+/// Application.persistentDataPath/gs_physics_probe.txt (+ BepInEx log).
+/// </summary>
+internal static class GroundedSprintPhysicsProbe
+{
+    private static readonly MethodInfo? HeroJumpBool =
+        AccessTools.Method(typeof(HeroController), "HeroJump", [typeof(bool)]);
+    private static readonly MethodInfo? DownAttackMethod =
+        AccessTools.Method(typeof(HeroController), "DoAttack");
+
+    private static readonly string ReportPath = Path.Combine(
+        Application.persistentDataPath, "gs_physics_probe.txt");
+
+    public static IEnumerator Run()
+    {
+        var log = new StringBuilder();
+        void L(string s)
+        {
+            log.AppendLine(s);
+            ItemChangerTestingPlugin.Instance.Logger.LogInfo("[GS-Probe] " + s);
+        }
+
+        L("=== GS Physics Probe start ===");
+        L($"time={System.DateTime.UtcNow:o}");
+
+        HeroController? hc = HeroController.instance;
+        if (hc == null)
+        {
+            L("FAIL: no HeroController");
+            Write(log);
+            yield break;
+        }
+
+        Rigidbody2D rb = hc.rb2d;
+        GroundedSprintModule? gs = ItemChangerHost.Singleton.ActiveProfile?.Modules
+            .Get<GroundedSprintModule>();
+        L($"module={gs != null} hasGroundedSprint={gs?.hasGroundedSprint}");
+        L($"onGround={hc.cState.onGround} isSprinting={hc.cState.isSprinting} CanJump={hc.CanJump()}");
+        L($"JUMP_SPEED={hc.JUMP_SPEED} walk={hc.GetWalkSpeed()}");
+
+        // Scenario 1: baseline jump
+        yield return WaitGrounded(hc);
+        ForceClearSprint(hc);
+        yield return SampleForcedJump(hc, rb, "baseline_jump", sprintFirst: false, log);
+
+        // Scenario 2: force isSprinting then HeroJump (old-bug reproduction path)
+        yield return WaitGrounded(hc);
+        ForceClearSprint(hc);
+        yield return SampleForcedJump(hc, rb, "sprint_jump_gs", sprintFirst: true, log);
+
+        // Scenario 3: jump then force DownAttack midair
+        yield return WaitGrounded(hc);
+        ForceClearSprint(hc);
+        hc.cState.isSprinting = true;
+        hc.sprintFSM?.SendEvent("TRY SPRINT");
+        yield return new WaitForFixedUpdate();
+        yield return new WaitForFixedUpdate();
+        HeroJumpBool?.Invoke(hc, [true]);
+
+        float maxVy = float.MinValue;
+        float minVy = float.MaxValue;
+        bool sawDownspike = false;
+        bool canAttackAtAir = false;
+        for (int i = 0; i < 50; i++)
+        {
+            yield return new WaitForFixedUpdate();
+            Vector2 v = rb.linearVelocity;
+            if (v.y > maxVy) maxVy = v.y;
+            if (v.y < minVy) minVy = v.y;
+
+            if (i == 8 && !hc.cState.onGround)
+            {
+                canAttackAtAir = hc.CanAttack();
+                L($"midair CanAttack={canAttackAtAir} isSprinting={hc.cState.isSprinting} acceptingInput={hc.acceptingInput} controlReq={hc.controlReqlinquished}");
+                if (canAttackAtAir)
+                    DownAttackMethod?.Invoke(hc, null);
+            }
+
+            if (hc.cState.downSpiking || hc.cState.downSpikeAntic || hc.cState.downAttacking)
+                sawDownspike = true;
+        }
+        L($"downspike_after_sprint_jump: maxVy={maxVy:F3} minVy={minVy:F3} sawDownspike={sawDownspike}");
+
+        L("=== GS Physics Probe done ===");
+        L($"report: {ReportPath}");
+        Write(log);
+    }
+
+    private static IEnumerator SampleForcedJump(
+        HeroController hc, Rigidbody2D rb, string name, bool sprintFirst, StringBuilder log)
+    {
+        if (sprintFirst)
+        {
+            hc.cState.isSprinting = true;
+            hc.sprintFSM?.SendEvent("TRY SPRINT");
+            // let FSM tick a couple frames while grounded
+            for (int i = 0; i < 8; i++)
+                yield return new WaitForFixedUpdate();
+        }
+
+        log.AppendLine($"pre {name}: isSprinting={hc.cState.isSprinting} CanJump={hc.CanJump()} onGround={hc.cState.onGround}");
+
+        Vector3 start = hc.transform.position;
+        float maxY = start.y;
+        float maxVy = float.MinValue;
+        int jumpApplyHints = 0;
+        int isSprintTrueFrames = 0;
+        var trace = new StringBuilder();
+
+        // Direct HeroJump(true) — exercises GS prefix + Jump() gate without input edges.
+        HeroJumpBool?.Invoke(hc, [true]);
+
+        for (int i = 0; i < 60; i++)
+        {
+            yield return new WaitForFixedUpdate();
+            Vector2 v = rb.linearVelocity;
+            float y = hc.transform.position.y;
+            if (y > maxY) maxY = y;
+            if (v.y > maxVy) maxVy = v.y;
+            if (hc.cState.isSprinting) isSprintTrueFrames++;
+            if (Mathf.Abs(v.y - hc.JUMP_SPEED) < 0.75f) jumpApplyHints++;
+            if (i < 12)
+                trace.Append($"[{i} dy={y - start.y:F2} vy={v.y:F2} sprint={hc.cState.isSprinting} jump={hc.cState.jumping}] ");
+            if (hc.cState.onGround && i > 8 && v.y <= 0.05f)
+                break;
+        }
+
+        float height = maxY - start.y;
+        string verdict = height < 0.8f ? "WEAK_HOP" : "OK_HEIGHT";
+        log.AppendLine($"scenario={name} height={height:F3} maxVy={maxVy:F3} jumpApply~={jumpApplyHints} sprintTrueFrames={isSprintTrueFrames} verdict={verdict}");
+        log.AppendLine($"  trace: {trace}");
+        ItemChangerTestingPlugin.Instance.Logger.LogInfo($"[GS-Probe] {name} height={height:F3} {verdict}");
+    }
+
+    private static IEnumerator WaitGrounded(HeroController hc)
+    {
+        float t0 = Time.time;
+        while ((!hc.cState.onGround || hc.cState.jumping) && Time.time - t0 < 4f)
+            yield return null;
+        for (int i = 0; i < 12; i++)
+            yield return new WaitForFixedUpdate();
+        ForceClearSprint(hc);
+    }
+
+    private static void ForceClearSprint(HeroController hc)
+    {
+        hc.cState.isSprinting = false;
+        hc.cState.isBackSprinting = false;
+        hc.cState.shuttleCock = false;
+        hc.sprintFSM?.SendEvent("CANCEL SPRINT");
+    }
+
+    private static void Write(StringBuilder log)
+    {
+        try
+        {
+            File.WriteAllText(ReportPath, log.ToString());
+        }
+        catch (System.Exception e)
+        {
+            ItemChangerTestingPlugin.Instance.Logger.LogError("[GS-Probe] write failed: " + e.Message);
+        }
+    }
+}

--- a/ItemChangerTesting/ModuleTests/GroundedSprintTest.cs
+++ b/ItemChangerTesting/ModuleTests/GroundedSprintTest.cs
@@ -1,0 +1,39 @@
+using Benchwarp.Data;
+using ItemChanger.Locations;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChangerTesting.ModuleTests;
+
+internal class GroundedSprintTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.ModuleTests,
+        MenuName = "Grounded Sprint",
+        MenuDescription = "Pickup grants Grounded Sprint. Hold dash on ground: vanilla sprint anim + Swift Step speed. Air: sprint cancels, walk speed, no shuttle-cock. Nearby Swift Step restores full vanilla sprint.",
+        Revision = 2026073001
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Tut_02, PrimitiveGateNames.right1);
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "GroundedSprintPickup",
+            SceneName = SceneNames.Tut_02,
+            X = 133.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Grounded_Sprint)!));
+        Profile.AddPlacement(new CoordinateLocation
+        {
+            Name = "SwiftStepPickup",
+            SceneName = SceneNames.Tut_02,
+            X = 136.6f,
+            Y = 31.57f,
+            FlingType = ItemChanger.Enums.FlingType.Everywhere,
+            Managed = false,
+        }.Wrap().Add(Finder.GetItem(ItemNames.Swift_Step)!));
+    }
+}

--- a/ItemChangerTesting/ModuleTests/GroundedSprintTest.cs
+++ b/ItemChangerTesting/ModuleTests/GroundedSprintTest.cs
@@ -1,6 +1,7 @@
 using Benchwarp.Data;
 using ItemChanger.Locations;
 using ItemChanger.Silksong.RawData;
+using UnityEngine;
 
 namespace ItemChangerTesting.ModuleTests;
 
@@ -10,8 +11,8 @@ internal class GroundedSprintTest : Test
     {
         Folder = TestFolder.ModuleTests,
         MenuName = "Grounded Sprint",
-        MenuDescription = "Pickup grants Grounded Sprint. Hold dash on ground: vanilla sprint anim + Swift Step speed. Air: sprint cancels, walk speed, no shuttle-cock. Nearby Swift Step restores full vanilla sprint.",
-        Revision = 2026073001
+        MenuDescription = "Pickup grants Grounded Sprint. Hold dash on ground: vanilla sprint anim + Swift Step speed. Air: sprint cancels, walk speed, no shuttle-cock. Nearby Swift Step restores full vanilla sprint. Test Methods → Run physics probe.",
+        Revision = 2026073101
     };
 
     public override void Setup(TestArgs args)
@@ -36,4 +37,14 @@ internal class GroundedSprintTest : Test
             Managed = false,
         }.Wrap().Add(Finder.GetItem(ItemNames.Swift_Step)!));
     }
+
+    public override IEnumerable<(string, Action)> TestMethods() =>
+    [
+        ("Run physics probe (jump / sprint-jump / downspike)", () =>
+        {
+            var host = ItemChangerTestingPlugin.Instance;
+            host.StartCoroutine(GroundedSprintPhysicsProbe.Run());
+            host.Logger.LogInfo("[GS] physics probe coroutine started — see BepInEx log + persistentDataPath/gs_physics_probe.txt");
+        }),
+    ];
 }

--- a/tools/gs-jump-sim/Program.cs
+++ b/tools/gs-jump-sim/Program.cs
@@ -1,0 +1,93 @@
+// Pure offline physics-gate simulation for Grounded Sprint jump.
+// Mirrors HeroController decomp (no Unity): Jump() only runs when
+//   jumping && !dashing && !isSprinting
+// and applies JUMP_SPEED each FixedUpdate step until jump_steps > JUMP_STEPS.
+//
+// Run:  dotnet run --project tools/gs-jump-sim
+
+const float JumpSpeed = 16.5f;       // placeholder; game uses HeroController.JUMP_SPEED
+const float Gravity = 60f;           // approximate; only for trajectory shape
+const float FixedDt = 1f / 50f;      // Silksong-ish fixed step
+const int JumpSteps = 12;            // JUMP_STEPS placeholder
+const int JumpStepsMin = 4;
+
+Console.WriteLine("=== Grounded Sprint Jump Gate Sim (HeroController decomp) ===\n");
+Console.WriteLine("Gate: if (jumping && !dashing && !isSprinting) Jump();");
+Console.WriteLine("Jump(): vy = JUMP_SPEED for jump_steps <= JUMP_STEPS\n");
+
+var scenarios = new (string Name, bool IsSprintingDuringJump, bool ClearSprintBeforeFixedUpdate)[]
+{
+    ("A: normal ground jump (no sprint)", false, false),
+    ("B: BUG — sprint jump, isSprinting stays true (old GS)", true, false),
+    ("C: FIX — sprint jump, clear isSprinting before FixedUpdate (new GS)", true, true),
+};
+
+foreach (var s in scenarios)
+{
+    var r = Simulate(s.IsSprintingDuringJump, s.ClearSprintBeforeFixedUpdate);
+    Console.WriteLine($"--- {s.Name} ---");
+    Console.WriteLine($"  peakY={r.PeakY:F3}  maxVy={r.MaxVy:F3}  framesWithJumpApply={r.JumpApplyFrames}  airTime={r.AirFrames}");
+    Console.WriteLine($"  first5 vy: {string.Join(", ", r.VyTrace.Take(5).Select(v => v.ToString("F2")))}");
+    Console.WriteLine(r.PeakY < 0.5f ? "  RESULT: WEAK HOP (matches playtest)" : "  RESULT: normal jump height");
+    Console.WriteLine();
+}
+
+// Downslash gate notes (not a full physics body, just documented conditions)
+Console.WriteLine("=== Downslash / Downspike notes (from decomp) ===");
+Console.WriteLine("CanAttackAction: blocks if hard_landing / !CanInput / downSpikeRecovery");
+Console.WriteLine("Downspike FixedUpdate: if (cState.downSpiking) Downspike() sets vy = -DownspikeSpeed");
+Console.WriteLine("If isSprinting holds controlReqlinquished, CanInput/CanAttack may fail.");
+Console.WriteLine("GS fix: FixedUpdate prefix clears isSprinting in air + skips X-clamp during downspike.");
+
+static SimResult Simulate(bool startSprinting, bool clearSprintBeforePhysics)
+{
+    bool jumping = true;
+    bool dashing = false;
+    bool isSprinting = startSprinting;
+    int jumpSteps = 0;
+    float y = 0f;
+    float vy = 0f;
+    float peakY = 0f;
+    float maxVy = 0f;
+    int jumpApply = 0;
+    int air = 0;
+    var vyTrace = new List<float>();
+
+    // HeroJump: sets jumping=true, does NOT set vy. BecomeAirborne zeros negative y vel only.
+    for (int i = 0; i < 80; i++)
+    {
+        // GS FixedUpdate PREFIX
+        if (clearSprintBeforePhysics && (jumping || y > 0.001f))
+            isSprinting = false;
+
+        // FixedUpdate jump gate (exact decomp structure)
+        if (jumping && !dashing && !isSprinting)
+        {
+            if (jumpSteps <= JumpSteps)
+            {
+                vy = JumpSpeed;
+                jumpSteps++;
+                jumpApply++;
+            }
+            else
+            {
+                jumping = false;
+            }
+        }
+
+        // crude gravity when not applying jump
+        if (!(jumping && !dashing && !isSprinting && jumpSteps <= JumpSteps + 1))
+            vy -= Gravity * FixedDt;
+
+        y += vy * FixedDt;
+        if (y < 0f) { y = 0f; vy = 0f; break; }
+        if (y > peakY) peakY = y;
+        if (vy > maxVy) maxVy = vy;
+        if (i < 20) vyTrace.Add(vy);
+        air++;
+    }
+
+    return new SimResult(peakY, maxVy, jumpApply, air, vyTrace);
+}
+
+readonly record struct SimResult(float PeakY, float MaxVy, int JumpApplyFrames, int AirFrames, List<float> VyTrace);

--- a/tools/gs-jump-sim/gs-jump-sim.csproj
+++ b/tools/gs-jump-sim/gs-jump-sim.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>GsJumpSim</RootNamespace>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Closes #52.

Grounded Sprint: hold dash on the ground to sprint with **vanilla sprint animations and cState**, without midair sprint or dash for logic.

## Approach (flibber review)

**Not** a `GetRunSpeed` speed hack. The sprintFSM's `PlayerDataBoolTest(hasDash)` gate is rewritten (named states first; discovery logs extras) to:

`hasDash || (hasGroundedSprint && onGround)`

so the vanilla FSM owns animations, Sprintmaster / Quickening tiers, and cState. Direct field `playerData.hasDash` stays false until real Swift Step (`CanDash`, progression).

### Extra guards (issue #52 air policy)
- Air: `CANCEL SPRINT` + clear `sprintBufferSteps`
- Ground sprint: `PreventShuttlecock()`
- `HeroJump(bool)` prefix blocks shuttle-cock when only Grounded Sprint is owned

## Test plan
- [ ] Hold dash on ground: sprint **animation** + Swift Step speed
- [ ] Leave ground while sprinting: cancels, walk speed, no shuttle-cock
- [ ] No air dash
- [ ] Full Swift Step restores vanilla
- [ ] Sprintmaster / Quickening tiers apply

FSM viewer: HeroController → sprintFSM → states with `PlayerDataBoolTest` / `hasDash` (see `KnownHasDashGateStates` + log line on first patch).