### PR TITLE
Add Creige Crafting Kit location

### DIFF
--- a/ItemChanger.Silksong/Locations/CreigeLocation.cs
+++ b/ItemChanger.Silksong/Locations/CreigeLocation.cs
@@ -1,0 +1,68 @@
+using ItemChanger.Locations;
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
+using QuestPlaymakerActions;
+using Silksong.FsmUtil;
+
+namespace ItemChanger.Silksong.Locations;
+
+/// <summary>
+/// Location for the Crafting Kit granted by Creige (HH Bartender) in Halfway_01
+/// after Hornet completes the Crawbug Clearing wish. Strips the GetQuestReward
+/// and SavedItemGet actions from the Dialogue FSM's "Quest Reward" state and
+/// routes the grant through the IC placement. The preceding "Quest Complete
+/// Prompt" state still runs EndQuest, so the wish closes normally.
+/// </summary>
+public class CreigeLocation : AutoLocation
+{
+    protected override void DoLoad()
+    {
+        Using(new FsmEditGroup()
+        {
+            { new(SceneName!, "HH Bartender", "Dialogue"), HookCreige },
+        });
+    }
+
+    protected override void DoUnload() { }
+
+    private void HookCreige(PlayMakerFSM fsm)
+    {
+        // First-time reward path (confirmed via UnityPy dump of
+        // scenes_scenes_scenes/halfway_01.bundle → HH Bartender Dialogue FSM):
+        //   Can Complete Dialogue → Quest Complete Yes No → accept →
+        //   Quest Complete Dialogue 1 → Quest Complete Prompt (EndQuest) →
+        //   Quest Complete Dialogue 2 → Quest Reward → Quest Complete Dialogue 3
+        //
+        // Quest Reward holds GetQuestReward + SavedItemGet. EndConversation
+        // before GiveAll so CrestUIDef does not stack on the NPC text box
+        // (qwint review on #212 / #208).
+        FsmState rewardState = fsm.MustGetState("Quest Reward");
+        rewardState.RemoveActionsOfType<GetQuestReward>();
+        rewardState.RemoveActionsOfType<SavedItemGet>();
+        rewardState.InsertLambdaMethod(0, finish =>
+        {
+            DialogueBox.EndConversation(true);
+            GiveAll(finish);
+        });
+
+        // Persistence / re-give path only after the wish is already complete.
+        // Quest State routes CheckQuestState COMPLETE → General Convos and
+        // never re-enters Quest Reward. Hook General Convos — NOT Quest State
+        // itself — because Quest State also runs for NONE / ACTIVE /
+        // Can Complete? and granting there lets the player take items before
+        // turning in Ragpelt (qwint retest 2026-07-19).
+        FsmState generalConvos = fsm.MustGetState("General Convos");
+        generalConvos.InsertLambdaMethod(0, finish =>
+        {
+            if (!Placement!.AllObtained())
+            {
+                DialogueBox.EndConversation(true);
+                GiveAll(finish);
+            }
+            else
+            {
+                finish();
+            }
+        });
+    }
+}

--- a/ItemChanger.Silksong/RawData/BaseLocationList/QuestItems.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/QuestItems.cs
@@ -11,6 +11,12 @@ namespace ItemChanger.Silksong.RawData;
 
 internal static partial class BaseLocationList
 {
+    public static Location Crafting_Kit__Creige => new CreigeLocation()
+    {
+        SceneName = SceneNames.Halfway_01,
+        Name = LocationNames.Crafting_Kit__Creige,
+    };
+
     public static Location Hermit_s_Soul => new DualLocation()
     {
         Name = LocationNames.Hermit_s_Soul,

--- a/ItemChangerTesting/LocationTests/CreigeLocationTest.cs
+++ b/ItemChangerTesting/LocationTests/CreigeLocationTest.cs
@@ -1,0 +1,53 @@
+using Benchwarp.Data;
+using ItemChanger;
+using ItemChanger.Silksong.Extensions;
+using ItemChanger.Silksong.RawData;
+
+namespace ItemChangerTesting.LocationTests;
+
+internal class CreigeLocationTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.LocationTests,
+        MenuName = "Creige Location",
+        MenuDescription = "Tests giving various items from the Creige Crafting Kit slot. Spawns next to Creige in Halfway_01 with the Crawbug Clearing wish ready-to-complete; talk to him to claim the reward.",
+        Revision = 2026050302
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Halfway_01, PrimitiveGateNames.right1);
+        Profile.AddPlacement(Finder.GetLocation(LocationNames.Crafting_Kit__Creige)!.Wrap()
+            .Add(Finder.GetItem(ItemNames.Surgeon_s_Key)!)
+            .Add(Finder.GetItem(ItemNames.Flea)!));
+    }
+
+    protected override void OnEnterGame()
+    {
+        base.OnEnterGame();
+
+        var pd = PlayerData.instance;
+        if (pd == null) return;
+
+        pd.SetInt(nameof(pd.nailUpgrades), 4);
+        pd.SetInt(nameof(pd.maxHealthBase), 99);
+        pd.SetInt(nameof(pd.maxHealth), 99);
+        pd.SetInt(nameof(pd.health), 99);
+        pd.SetInt(nameof(pd.geo), 9999);
+
+        pd.SetBool(nameof(pd.hasBrolly), true);
+        pd.SetBool(nameof(pd.hasChargeSlash), true);
+        pd.SetBool(nameof(pd.hasDash), true);
+        pd.SetBool(nameof(pd.hasDoubleJump), true);
+        pd.SetBool(nameof(pd.hasHarpoonDash), true);
+        pd.SetBool(nameof(pd.hasNeedolin), true);
+        pd.SetBool(nameof(pd.hasNeedolinMemoryPowerup), true);
+        pd.SetBool("hasSilkSpoolAppeared", true);
+        pd.SetBool(nameof(pd.hasSuperJump), true);
+        pd.SetBool(nameof(pd.hasWalljump), true);
+
+        QuestUtil.SetReadyToComplete(Quests.Crow_Feathers_Pre);
+        QuestUtil.SetReadyToComplete(Quests.Crow_Feathers);
+    }
+}


### PR DESCRIPTION
- Adds `CreigeLocation`, an `AutoLocation` that hooks the `HH Bartender / Dialogue` FSM in `Halfway_01` and routes the Crafting Kit grant from the Crawbug Clearing wish through ItemChanger.
- Strips `GetQuestReward` and `SavedItemGet` from the `Quest Reward` state, ends conversation, then `GiveAll` (crest UI no longer stacks on NPC text).
- Persistence / re-give hooks **`General Convos` only** (after quest COMPLETE). Does **not** grant from `Quest State` (that path also runs before Ragpelt turn-in).
- Registers `Crafting_Kit__Creige` in `BaseLocationList` pointing at the new location.
- Adds a `Creige Location` test under `LocationTests` that places `Surgeon's Key` and `Flea` at the slot, spawns near Creige in `Halfway_01`, and marks the Crawbug Clearing quest ready-to-complete.

- [x] Build solution
- [x] Address review: crest text-box clear before GiveAll
- [x] Address review: persistence without early grant on first dialogue
- [x] Confirm vanilla Crafting Kit no longer appears (no double-grant)

Closes #136.