### PR TITLE
implementation of loddie locations

### DIFF
--- a/ItemChanger.Silksong/Locations/LoddieAct3DeskLocation.cs
+++ b/ItemChanger.Silksong/Locations/LoddieAct3DeskLocation.cs
@@ -1,0 +1,39 @@
+using ItemChanger.Locations;
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
+using Silksong.FsmUtil;
+
+namespace ItemChanger.Silksong.Locations;
+
+public class LoddieAct3DeskLocation : AutoLocation
+{
+    protected override void DoLoad()
+    {
+        Using(new FsmEditGroup()
+        {
+            { new(SceneName!, "Ladybug Craft Pickup", "FSM"), HookLoddieAct3Desk }
+        });
+    }
+
+    protected override void DoUnload() { }
+
+    private void HookLoddieAct3Desk(PlayMakerFSM fsm)//location is the desk that has the alternative placement for the tool pouch upgrade
+    {
+        FsmState toolPouchState = fsm.MustGetState("Get Item");
+        toolPouchState.RemoveActionsOfType<SavedItemGet>();
+        toolPouchState.InsertLambdaMethod(1, GiveAll);
+
+        //skip tool pouch yes/no prompt
+        fsm.RemoveTransitionsTo("Idle", "Inspect");
+        fsm.AddTransition("Idle", "INTERACT", "Wait");//bypass Idle -> Inspect path to Idle -> Wait
+        //skip tool pouch creation cutscene/animation with fade to black
+        fsm.MustGetState("Wait").RemoveActionsOfType<Wait>();//removing 0.3s of waiting
+        fsm.MustGetState("Hero Face Table").RemoveActionsOfType<ScreenFader>();
+        fsm.MustGetState("Hero Face Table").RemoveActionsOfType<Wait>();//removing 1.5s of waiting
+        fsm.RemoveTransitionsTo("Hero Face Table", "Craft");
+        fsm.AddTransition("Hero Face Table", "FINISHED", "Turn Back");//bypass Hero Face Table -> Craft path to Hero Face Table -> Turn Back
+        fsm.MustGetState("Turn Back").RemoveActionsOfType<ScreenFader>();
+        fsm.MustGetState("Turn Back").RemoveActionsOfType<Wait>();//remove 0.5s of waiting
+        
+    }
+}

--- a/ItemChanger.Silksong/Locations/LoddieChallenge1Location.cs
+++ b/ItemChanger.Silksong/Locations/LoddieChallenge1Location.cs
@@ -1,0 +1,26 @@
+using ItemChanger.Locations;
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
+using Silksong.FsmUtil;
+
+namespace ItemChanger.Silksong.Locations;
+
+public class LoddieChallenge1Location : AutoLocation
+{
+    protected override void DoLoad()
+    {
+        Using(new FsmEditGroup()
+        {
+            { new(SceneName!, "Lady Bug Large", "Convo"), HookLoddieChallenge1 }
+        });
+    }
+
+    protected override void DoUnload() { }
+
+    private void HookLoddieChallenge1(PlayMakerFSM fsm)
+    {
+        FsmState reward1State = fsm.MustGetState("Reward 1");//tool pouch for challenge 1
+        reward1State.RemoveActionsOfType<RunFSM>();
+        reward1State.InsertLambdaMethod(1, GiveAll);
+    }
+}

--- a/ItemChanger.Silksong/Locations/LoddieChallenge2Location.cs
+++ b/ItemChanger.Silksong/Locations/LoddieChallenge2Location.cs
@@ -1,0 +1,26 @@
+using ItemChanger.Locations;
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
+using Silksong.FsmUtil;
+
+namespace ItemChanger.Silksong.Locations;
+
+public class LoddieChallenge2Location : AutoLocation
+{
+    protected override void DoLoad()
+    {
+        Using(new FsmEditGroup()
+        {
+            { new(SceneName!, "Lady Bug Large", "Convo"), HookLoddieChallenge2 }
+        });
+    }
+
+    protected override void DoUnload() { }
+
+    private void HookLoddieChallenge2(PlayMakerFSM fsm)
+    {
+        FsmState reward2State = fsm.MustGetState("Reward 2");//heavy rosary necklace for challenge 2
+        reward2State.RemoveActionsOfType<CollectableItemCollect>();
+        reward2State.InsertLambdaMethod(0, GiveAll);
+    }
+}

--- a/ItemChanger.Silksong/RawData/BaseLocationList/LoddieLocations.cs
+++ b/ItemChanger.Silksong/RawData/BaseLocationList/LoddieLocations.cs
@@ -1,0 +1,44 @@
+using Benchwarp.Data;
+using ItemChanger.Locations;
+using ItemChanger.Serialization;
+using ItemChanger.Silksong.Containers;
+using ItemChanger.Silksong.Locations;
+using ItemChanger.Silksong.Serialization;
+using ItemChanger.Tags;
+
+namespace ItemChanger.Silksong.RawData;
+
+internal static partial class BaseLocationList
+{
+    public static Location Tool_Pouch__Loddie => new DualLocation()
+    {
+        Name = LocationNames.Tool_Pouch__Loddie,
+        Test = new PDBool(nameof(PlayerData.blackThreadWorld)),
+        TrueLocation = new LoddieAct3DeskLocation()//if act 3 (desk location)
+        {
+            Name = LocationNames.Tool_Pouch__Loddie,
+            SceneName = SceneNames.Bone_12
+        },
+        FalseLocation = new LoddieChallenge1Location()//if not act 3 (loddie challenge 1 location)
+        {
+            Name = LocationNames.Tool_Pouch__Loddie,
+            SceneName = SceneNames.Bone_12
+        }
+        
+    };
+    public static Location Heavy_Rosary_Necklace__Loddie_Challenge_2 => new DualLocation()
+    {
+        Name = LocationNames.Heavy_Rosary_Necklace__Loddie_Challenge_2,
+        Test = new PDBool(nameof(PlayerData.blackThreadWorld)),
+        TrueLocation = new EmptyLocation()//if act 3 (no location)
+        {
+            Name = LocationNames.Heavy_Rosary_Necklace__Loddie_Challenge_2
+        },
+        FalseLocation = new LoddieChallenge2Location()//if not act 3 (loddie challenge 2 location)
+        {
+            Name = LocationNames.Heavy_Rosary_Necklace__Loddie_Challenge_2,
+            SceneName = SceneNames.Bone_12
+        }
+
+    };
+}

--- a/ItemChangerTesting/LocationTests/LoddieLocationsTest.cs
+++ b/ItemChangerTesting/LocationTests/LoddieLocationsTest.cs
@@ -1,0 +1,35 @@
+using Benchwarp.Data;
+using ItemChanger.Silksong.Extensions;
+using ItemChanger.Silksong.RawData;
+using ItemChanger.Silksong.StartDefs;
+
+namespace ItemChangerTesting.LocationTests;
+
+internal class LoddieLocationsTest : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.LocationTests,
+        MenuName = "Loddie Locations",
+        MenuDescription = "Tests modifying Loddie Challenges in-place to give Surgeon's_Key and Flea.",
+        Revision = 2026050200
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Bone_12, PrimitiveGateNames.left1);
+        Profile.AddPlacement(Finder.GetLocation(LocationNames.Tool_Pouch__Loddie)!.Wrap()
+            .Add(Finder.GetItem(ItemNames.Surgeon_s_Key)!)
+            .Add(Finder.GetItem(ItemNames.Flea)!));
+        Profile.AddPlacement(Finder.GetLocation(LocationNames.Heavy_Rosary_Necklace__Loddie_Challenge_2)!.Wrap()
+            .Add(Finder.GetItem(ItemNames.Surgeon_s_Key)!)
+            .Add(Finder.GetItem(ItemNames.Flea)!));
+    }
+
+    protected override void OnEnterGame()
+    {
+        base.OnEnterGame();
+        PlayerData.instance.IsPinGallerySetup = true;
+        PlayerData.instance.SetInt(nameof(PlayerData.instance.geo), 9999999);
+    }
+}

--- a/ItemChangerTesting/LocationTests/LoddieLocationsTestAct3.cs
+++ b/ItemChangerTesting/LocationTests/LoddieLocationsTestAct3.cs
@@ -1,0 +1,37 @@
+using Benchwarp.Data;
+using ItemChanger.Silksong.Extensions;
+using ItemChanger.Silksong.RawData;
+using ItemChanger.Silksong.StartDefs;
+
+namespace ItemChangerTesting.LocationTests;
+
+internal class LoddieLocationsTestAct3 : Test
+{
+    public override TestMetadata GetMetadata() => new()
+    {
+        Folder = TestFolder.LocationTests,
+        MenuName = "Loddie Locations (act 3)",
+        MenuDescription = "Tests modifying Loddie Challenges in-place to give Surgeon's_Key and Flea. (act 3)",
+        Revision = 2026050200
+    };
+
+    public override void Setup(TestArgs args)
+    {
+        StartNear(SceneNames.Bone_12, PrimitiveGateNames.left1);
+        Profile.AddPlacement(Finder.GetLocation(LocationNames.Tool_Pouch__Loddie)!.Wrap()
+            .Add(Finder.GetItem(ItemNames.Surgeon_s_Key)!)
+            .Add(Finder.GetItem(ItemNames.Flea)!));
+        Profile.AddPlacement(Finder.GetLocation(LocationNames.Heavy_Rosary_Necklace__Loddie_Challenge_2)!.Wrap()
+            .Add(Finder.GetItem(ItemNames.Surgeon_s_Key)!)
+            .Add(Finder.GetItem(ItemNames.Flea)!));
+    }
+
+    protected override void OnEnterGame()
+    {
+        base.OnEnterGame();
+        PlayerData.instance.IsPinGallerySetup = true;
+        PlayerData.instance.blackThreadWorld = true;
+        PlayerData.instance.act3_wokeUp = true;
+        PlayerData.instance.act3_enclaveWakeSceneCompleted = true;
+    }
+}


### PR DESCRIPTION
-added locations for the two challenge rewards from loddie (tool pouch upgrade, heavy rosary necklace) and their act 3 locations
-modified the tool pouch act 3 location to skip the tool pouch prompt and crafting animation

this does not include proposed qol change of merging the two loddie challenges together

(fixes https://github.com/homothetyhk/ItemChanger.Silksong/issues/128)