### PR TITLE
Fix rosary spawn bugs.

### DIFF
--- a/ItemChanger.Silksong/Items/CurrencyItem.cs
+++ b/ItemChanger.Silksong/Items/CurrencyItem.cs
@@ -2,6 +2,7 @@
 using ItemChanger.Events.Args;
 using ItemChanger.Items;
 using ItemChanger.Silksong.Containers;
+using ItemChanger.Silksong.Modules;
 using ItemChanger.Silksong.Tags;
 using Newtonsoft.Json;
 using UnityEngine;
@@ -20,6 +21,7 @@ public abstract class CurrencyItem : Item
     protected override void DoLoad()
     {
         base.DoLoad();
+        ActiveProfile!.Modules.GetOrAdd<RemoveCurrencyCapModule>();
         OnGive += CheckMegaFling;
     }
 

--- a/ItemChanger.Silksong/Items/RosariesItem.cs
+++ b/ItemChanger.Silksong/Items/RosariesItem.cs
@@ -38,11 +38,7 @@ public class RosariesItem : CurrencyItem
         remaining -= 5 * medium;
         yield return (medium, Gameplay.MediumGeoPrefab);
 
-        // Make large rosaries (value 15), approx 1/3 of them smooth.
-        int large = remaining / 15;
-        int smooth = 0;
-        for (int i = 0; i < large; i++) if (UnityEngine.Random.Range(0, 3) == 1) ++smooth;
-        yield return (smooth, Gameplay.LargeSmoothGeoPrefab);
-        yield return (large - smooth, Gameplay.LargeGeoPrefab);
+        // Make large rosaries (value 15).
+        yield return (remaining / 15, Gameplay.LargeGeoPrefab);
     }
 }

--- a/ItemChanger.Silksong/Modules/RemoveCurrencyCapModule.cs
+++ b/ItemChanger.Silksong/Modules/RemoveCurrencyCapModule.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using ItemChanger.Modules;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace ItemChanger.Silksong.Modules;
+
+/// <summary>
+/// ObjectPool spawning logic has a hard-coded exception to forcibly recycle currency items if the pool is depleted.
+/// We disable this behaviour to force new currency objects to spawn instead.
+/// </summary>
+public class RemoveCurrencyCapModule : Module
+{
+    protected override void DoLoad() => Using(new HarmonyPatchGroup() { typeof(Patches) });
+
+    protected override void DoUnload() { }
+
+    [HarmonyPatch]
+    private static class Patches
+    {
+        [HarmonyPatch(typeof(ObjectPool), nameof(ObjectPool.Spawn), [typeof(GameObject), typeof(Transform), typeof(Vector3), typeof(Quaternion), typeof(bool)])]
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> source)
+        {
+            var methodInfo = typeof(GameObject).GetMethod(nameof(GameObject.GetComponent), types: []).MakeGenericMethod(typeof(CurrencyObjectBase));
+            foreach (var instruction in source)
+            {
+                if (instruction.Calls(methodInfo))
+                {
+                    // Pretend this isn't a currency object to avoid reuse behaviour.
+                    yield return new(OpCodes.Pop);  // Pop the GameObject argument.
+                    yield return new(OpCodes.Ldnull);  // Push a null onto the stack for the GetComponent<>() return value.
+                }
+                else
+                    yield return instruction;
+            }
+        }
+    }
+}

--- a/ItemChangerTesting/ItemTests/CurrencyItemsTest.cs
+++ b/ItemChangerTesting/ItemTests/CurrencyItemsTest.cs
@@ -47,5 +47,7 @@ internal class CurrencyItemsTest : Test
         PlaceCurrency(index++, rosaries: 21, shellShards: 0);
         PlaceCurrency(index++, rosaries: 0, shellShards: 21);
         PlaceCurrency(index++, rosaries: 77, shellShards: 22);
+        PlaceCurrency(index++, rosaries: 666, shellShards: 0);
+        PlaceCurrency(index++, rosaries: 0, shellShards: 104);
     }
 }


### PR DESCRIPTION
This removes the cap on currency item spawns to prevent scams.

While not necessary, this also removes the large smooth geo prefab from rosary distribution.  The fix for the above makes them now spawn correctly, but they all render in front of the other currency which looks weird.